### PR TITLE
test: add unit tests for cmd/mysql-mcp-server package

### DIFF
--- a/cmd/mysql-mcp-server/connection_test.go
+++ b/cmd/mysql-mcp-server/connection_test.go
@@ -1,0 +1,309 @@
+// cmd/mysql-mcp-server/connection_test.go
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/askdba/mysql-mcp-server/internal/config"
+)
+
+func TestNewConnectionManager(t *testing.T) {
+	cm := NewConnectionManager()
+	if cm == nil {
+		t.Fatal("NewConnectionManager returned nil")
+	}
+	if cm.connections == nil {
+		t.Error("connections map should be initialized")
+	}
+	if cm.configs == nil {
+		t.Error("configs map should be initialized")
+	}
+	if cm.activeConn != "" {
+		t.Error("activeConn should be empty initially")
+	}
+}
+
+func TestConnectionManagerGetActiveEmpty(t *testing.T) {
+	cm := NewConnectionManager()
+	db, name := cm.GetActive()
+	if db != nil {
+		t.Error("GetActive should return nil when no connections")
+	}
+	if name != "" {
+		t.Error("GetActive name should be empty when no connections")
+	}
+}
+
+func TestConnectionManagerSetActiveNotFound(t *testing.T) {
+	cm := NewConnectionManager()
+	err := cm.SetActive("nonexistent")
+	if err == nil {
+		t.Error("SetActive should error for nonexistent connection")
+	}
+	if err.Error() != "connection 'nonexistent' not found" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestConnectionManagerListEmpty(t *testing.T) {
+	cm := NewConnectionManager()
+	list := cm.List()
+	if len(list) != 0 {
+		t.Errorf("expected empty list, got %d items", len(list))
+	}
+}
+
+func TestConnectionManagerClose(t *testing.T) {
+	cm := NewConnectionManager()
+	// Should not panic when closing empty manager
+	cm.Close()
+}
+
+func TestConnectionManagerWithMockDB(t *testing.T) {
+	// Create mock database
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	// Expect ping
+	mock.ExpectPing()
+
+	cm := NewConnectionManager()
+	
+	// Manually add the mock connection (bypassing AddConnectionWithPoolConfig)
+	cm.connections["test"] = mockDB
+	cm.configs["test"] = config.ConnectionConfig{
+		Name:        "test",
+		DSN:         "user:password@tcp(localhost:3306)/testdb",
+		Description: "Test connection",
+	}
+	cm.activeConn = "test"
+
+	// Test GetActive
+	db, name := cm.GetActive()
+	if db != mockDB {
+		t.Error("GetActive should return the mock db")
+	}
+	if name != "test" {
+		t.Errorf("expected name 'test', got '%s'", name)
+	}
+
+	// Test GetActiveDB
+	activeDB := cm.GetActiveDB()
+	if activeDB != mockDB {
+		t.Error("GetActiveDB should return the mock db")
+	}
+
+	// Test List with masking
+	list := cm.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(list))
+	}
+	if list[0].Name != "test" {
+		t.Errorf("expected name 'test', got '%s'", list[0].Name)
+	}
+	// DSN should be masked
+	if list[0].DSN == "user:password@tcp(localhost:3306)/testdb" {
+		t.Error("DSN should be masked in List output")
+	}
+
+	// Test SetActive
+	err = cm.SetActive("test")
+	if err != nil {
+		t.Errorf("SetActive should succeed: %v", err)
+	}
+
+	// Test Close
+	cm.Close()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestConnectionManagerMultipleConnections(t *testing.T) {
+	// Create two mock databases
+	mockDB1, mock1, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock1: %v", err)
+	}
+	defer mockDB1.Close()
+
+	mockDB2, mock2, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock2: %v", err)
+	}
+	defer mockDB2.Close()
+
+	mock1.ExpectPing()
+	mock2.ExpectPing()
+
+	cm := NewConnectionManager()
+
+	// Add connections manually
+	cm.connections["conn1"] = mockDB1
+	cm.configs["conn1"] = config.ConnectionConfig{
+		Name:        "conn1",
+		DSN:         "user1:pass1@tcp(host1:3306)/db1",
+		Description: "Connection 1",
+	}
+	cm.activeConn = "conn1"
+
+	cm.connections["conn2"] = mockDB2
+	cm.configs["conn2"] = config.ConnectionConfig{
+		Name:        "conn2",
+		DSN:         "user2:pass2@tcp(host2:3306)/db2",
+		Description: "Connection 2",
+	}
+
+	// Verify first is active
+	_, name := cm.GetActive()
+	if name != "conn1" {
+		t.Errorf("expected active 'conn1', got '%s'", name)
+	}
+
+	// Switch to second
+	err = cm.SetActive("conn2")
+	if err != nil {
+		t.Fatalf("SetActive failed: %v", err)
+	}
+
+	db, name := cm.GetActive()
+	if name != "conn2" {
+		t.Errorf("expected active 'conn2', got '%s'", name)
+	}
+	if db != mockDB2 {
+		t.Error("active db should be mockDB2")
+	}
+
+	// List should return both
+	list := cm.List()
+	if len(list) != 2 {
+		t.Errorf("expected 2 connections, got %d", len(list))
+	}
+
+	cm.Close()
+	_ = mock1.ExpectationsWereMet()
+	_ = mock2.ExpectationsWereMet()
+}
+
+func TestGetDBWithConnManager(t *testing.T) {
+	// Create mock database
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	// Save and restore global state
+	oldConnManager := connManager
+	oldDB := db
+	defer func() {
+		connManager = oldConnManager
+		db = oldDB
+	}()
+
+	// Set up connection manager
+	cm := NewConnectionManager()
+	cm.connections["test"] = mockDB
+	cm.activeConn = "test"
+	connManager = cm
+
+	// getDB should return the manager's active connection
+	result := getDB()
+	if result != mockDB {
+		t.Error("getDB should return connection manager's active db")
+	}
+}
+
+func TestGetDBWithoutConnManager(t *testing.T) {
+	// Create mock database
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	// Save and restore global state
+	oldConnManager := connManager
+	oldDB := db
+	defer func() {
+		connManager = oldConnManager
+		db = oldDB
+	}()
+
+	// Set global db, no connection manager
+	connManager = nil
+	db = mockDB
+
+	// getDB should return global db
+	result := getDB()
+	if result != mockDB {
+		t.Error("getDB should return global db when connManager is nil")
+	}
+}
+
+func TestConnectionConfigStruct(t *testing.T) {
+	cfg := config.ConnectionConfig{
+		Name:        "production",
+		DSN:         "root:secret@tcp(prod.mysql.example.com:3306)/app",
+		Description: "Production database",
+	}
+
+	if cfg.Name != "production" {
+		t.Error("Name mismatch")
+	}
+	if cfg.DSN == "" {
+		t.Error("DSN should not be empty")
+	}
+	if cfg.Description != "Production database" {
+		t.Error("Description mismatch")
+	}
+}
+
+func TestConnectionManagerConcurrency(t *testing.T) {
+	// Create mock database
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	mock.ExpectPing()
+
+	cm := NewConnectionManager()
+	cm.connections["test"] = mockDB
+	cm.configs["test"] = config.ConnectionConfig{Name: "test", DSN: "test:test@tcp(localhost)/test"}
+	cm.activeConn = "test"
+
+	// Concurrent reads
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = cm.GetActiveDB()
+				_ = cm.List()
+				_, _ = cm.GetActive()
+			}
+			done <- true
+		}()
+	}
+
+	// Concurrent SetActive
+	go func() {
+		for j := 0; j < 100; j++ {
+			_ = cm.SetActive("test")
+			time.Sleep(time.Microsecond)
+		}
+		done <- true
+	}()
+
+	// Wait for all
+	for i := 0; i < 11; i++ {
+		<-done
+	}
+}
+

--- a/cmd/mysql-mcp-server/logging_test.go
+++ b/cmd/mysql-mcp-server/logging_test.go
@@ -1,0 +1,298 @@
+// cmd/mysql-mcp-server/logging_test.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewQueryTimer(t *testing.T) {
+	timer := NewQueryTimer("test_tool")
+	if timer == nil {
+		t.Fatal("NewQueryTimer returned nil")
+	}
+	if timer.tool != "test_tool" {
+		t.Errorf("expected tool 'test_tool', got '%s'", timer.tool)
+	}
+
+	// Verify timing works
+	time.Sleep(10 * time.Millisecond)
+	elapsed := timer.Elapsed()
+	if elapsed < 10*time.Millisecond {
+		t.Errorf("expected elapsed >= 10ms, got %v", elapsed)
+	}
+
+	elapsedMs := timer.ElapsedMs()
+	if elapsedMs < 10 {
+		t.Errorf("expected elapsedMs >= 10, got %d", elapsedMs)
+	}
+}
+
+func TestQueryTimerLogSuccess(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	timer := NewQueryTimer("test_query")
+	timer.LogSuccess(5, "SELECT * FROM test")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain log output
+	if !strings.Contains(output, "test_query") && !strings.Contains(output, "query executed") {
+		// Either JSON or plain log format should work
+		t.Logf("Log output: %s", output)
+	}
+}
+
+func TestQueryTimerLogError(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	timer := NewQueryTimer("test_query")
+	timer.LogError(os.ErrNotExist, "SELECT * FROM test")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain error info
+	if !strings.Contains(output, "test_query") && !strings.Contains(output, "failed") {
+		t.Logf("Log output: %s", output)
+	}
+}
+
+func TestNewAuditLoggerDisabled(t *testing.T) {
+	logger, err := NewAuditLogger("")
+	if err != nil {
+		t.Fatalf("NewAuditLogger with empty path should not error: %v", err)
+	}
+	if logger == nil {
+		t.Fatal("NewAuditLogger returned nil")
+	}
+	if logger.enabled {
+		t.Error("logger should be disabled with empty path")
+	}
+
+	// Logging to disabled logger should not panic
+	logger.Log(&AuditEntry{
+		Tool:    "test",
+		Query:   "SELECT 1",
+		Success: true,
+	})
+
+	logger.Close()
+}
+
+func TestNewAuditLoggerEnabled(t *testing.T) {
+	// Create temp file
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "audit.log")
+
+	logger, err := NewAuditLogger(logPath)
+	if err != nil {
+		t.Fatalf("NewAuditLogger failed: %v", err)
+	}
+	defer logger.Close()
+
+	if !logger.enabled {
+		t.Error("logger should be enabled")
+	}
+	if logger.file == nil {
+		t.Error("logger file should not be nil")
+	}
+
+	// Log an entry
+	logger.Log(&AuditEntry{
+		Tool:       "test_tool",
+		Database:   "testdb",
+		Query:      "SELECT * FROM users",
+		DurationMs: 42,
+		RowCount:   10,
+		Success:    true,
+	})
+
+	// Close and verify file contents
+	logger.Close()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read audit log: %v", err)
+	}
+
+	var entry AuditEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("failed to parse audit log entry: %v", err)
+	}
+
+	if entry.Tool != "test_tool" {
+		t.Errorf("expected tool 'test_tool', got '%s'", entry.Tool)
+	}
+	if entry.Database != "testdb" {
+		t.Errorf("expected database 'testdb', got '%s'", entry.Database)
+	}
+	if entry.Query != "SELECT * FROM users" {
+		t.Errorf("expected query 'SELECT * FROM users', got '%s'", entry.Query)
+	}
+	if entry.DurationMs != 42 {
+		t.Errorf("expected duration 42, got %d", entry.DurationMs)
+	}
+	if entry.RowCount != 10 {
+		t.Errorf("expected row_count 10, got %d", entry.RowCount)
+	}
+	if !entry.Success {
+		t.Error("expected success true")
+	}
+	if entry.Timestamp == "" {
+		t.Error("timestamp should be set")
+	}
+}
+
+func TestNewAuditLoggerInvalidPath(t *testing.T) {
+	// Try to create logger with invalid path
+	logger, err := NewAuditLogger("/nonexistent/directory/audit.log")
+	if err == nil {
+		logger.Close()
+		t.Error("expected error for invalid path")
+	}
+}
+
+func TestAuditLoggerConcurrency(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "audit_concurrent.log")
+
+	logger, err := NewAuditLogger(logPath)
+	if err != nil {
+		t.Fatalf("NewAuditLogger failed: %v", err)
+	}
+	defer logger.Close()
+
+	// Concurrent writes
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			for j := 0; j < 10; j++ {
+				logger.Log(&AuditEntry{
+					Tool:    "concurrent_test",
+					Query:   "SELECT " + string(rune('0'+n)),
+					Success: true,
+				})
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	logger.Close()
+
+	// Verify file has entries
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read audit log: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 100 {
+		t.Errorf("expected 100 log entries, got %d", len(lines))
+	}
+}
+
+func TestLogEntry(t *testing.T) {
+	entry := LogEntry{
+		Timestamp: "2025-01-01T00:00:00Z",
+		Level:     "INFO",
+		Message:   "test message",
+		Fields: map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("failed to marshal LogEntry: %v", err)
+	}
+
+	var parsed LogEntry
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal LogEntry: %v", err)
+	}
+
+	if parsed.Level != "INFO" {
+		t.Errorf("expected level 'INFO', got '%s'", parsed.Level)
+	}
+	if parsed.Message != "test message" {
+		t.Errorf("expected message 'test message', got '%s'", parsed.Message)
+	}
+}
+
+func TestAuditEntry(t *testing.T) {
+	entry := AuditEntry{
+		Timestamp:  "2025-01-01T00:00:00Z",
+		Tool:       "run_query",
+		Database:   "testdb",
+		Query:      "SELECT 1",
+		DurationMs: 100,
+		RowCount:   1,
+		Success:    true,
+		Error:      "",
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("failed to marshal AuditEntry: %v", err)
+	}
+
+	var parsed AuditEntry
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal AuditEntry: %v", err)
+	}
+
+	if parsed.Tool != "run_query" {
+		t.Errorf("expected tool 'run_query', got '%s'", parsed.Tool)
+	}
+	if parsed.DurationMs != 100 {
+		t.Errorf("expected duration_ms 100, got %d", parsed.DurationMs)
+	}
+}
+
+func TestAuditEntryWithError(t *testing.T) {
+	entry := AuditEntry{
+		Timestamp:  "2025-01-01T00:00:00Z",
+		Tool:       "run_query",
+		Database:   "testdb",
+		Query:      "SELECT * FROM nonexistent",
+		DurationMs: 5,
+		Success:    false,
+		Error:      "table does not exist",
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("failed to marshal AuditEntry: %v", err)
+	}
+
+	if !strings.Contains(string(data), "table does not exist") {
+		t.Error("error message should be in JSON output")
+	}
+}
+

--- a/cmd/mysql-mcp-server/tools_test.go
+++ b/cmd/mysql-mcp-server/tools_test.go
@@ -1,0 +1,492 @@
+// cmd/mysql-mcp-server/tools_test.go
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/askdba/mysql-mcp-server/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// setupMockDB sets up a mock database and configures global state for testing
+func setupMockDB(t *testing.T) (sqlmock.Sqlmock, func()) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	// Save original state
+	oldConnManager := connManager
+	oldDB := db
+	oldMaxRows := maxRows
+	oldQueryTimeout := queryTimeout
+
+	// Set up global state
+	db = mockDB
+	connManager = nil
+	maxRows = 1000
+	queryTimeout = 30 * time.Second
+
+	cleanup := func() {
+		connManager = oldConnManager
+		db = oldDB
+		maxRows = oldMaxRows
+		queryTimeout = oldQueryTimeout
+		mockDB.Close()
+	}
+
+	return mock, cleanup
+}
+
+func TestToolListDatabases(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	// Set up expected query
+	rows := sqlmock.NewRows([]string{"Database"}).
+		AddRow("information_schema").
+		AddRow("mysql").
+		AddRow("testdb")
+	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(rows)
+
+	// Call the tool
+	ctx := context.Background()
+	_, output, err := toolListDatabases(ctx, &mcp.CallToolRequest{}, ListDatabasesInput{})
+
+	if err != nil {
+		t.Fatalf("toolListDatabases failed: %v", err)
+	}
+
+	if len(output.Databases) != 3 {
+		t.Errorf("expected 3 databases, got %d", len(output.Databases))
+	}
+
+	expectedDBs := []string{"information_schema", "mysql", "testdb"}
+	for i, expected := range expectedDBs {
+		if output.Databases[i].Name != expected {
+			t.Errorf("expected database '%s', got '%s'", expected, output.Databases[i].Name)
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolListTablesSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"Tables_in_testdb"}).
+		AddRow("users").
+		AddRow("orders").
+		AddRow("products")
+	mock.ExpectQuery("SHOW TABLES FROM `testdb`").WillReturnRows(rows)
+
+	ctx := context.Background()
+	_, output, err := toolListTables(ctx, &mcp.CallToolRequest{}, ListTablesInput{Database: "testdb"})
+
+	if err != nil {
+		t.Fatalf("toolListTables failed: %v", err)
+	}
+
+	if len(output.Tables) != 3 {
+		t.Errorf("expected 3 tables, got %d", len(output.Tables))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolListTablesEmptyDatabase(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, _, err := toolListTables(ctx, &mcp.CallToolRequest{}, ListTablesInput{Database: ""})
+
+	if err == nil {
+		t.Error("expected error for empty database")
+	}
+	if err.Error() != "database is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolDescribeTableSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"Field", "Type", "Collation", "Null", "Key", "Default", "Extra", "Privileges", "Comment"}).
+		AddRow("id", "int", "", "NO", "PRI", "", "auto_increment", "select,insert,update,references", "").
+		AddRow("name", "varchar(255)", "utf8mb4_general_ci", "NO", "", "", "", "select,insert,update,references", "User name").
+		AddRow("email", "varchar(255)", "utf8mb4_general_ci", "YES", "UNI", "", "", "select,insert,update,references", "")
+
+	mock.ExpectQuery("SHOW FULL COLUMNS FROM `testdb`.`users`").WillReturnRows(rows)
+
+	ctx := context.Background()
+	_, output, err := toolDescribeTable(ctx, &mcp.CallToolRequest{}, DescribeTableInput{
+		Database: "testdb",
+		Table:    "users",
+	})
+
+	if err != nil {
+		t.Fatalf("toolDescribeTable failed: %v", err)
+	}
+
+	if len(output.Columns) != 3 {
+		t.Errorf("expected 3 columns, got %d", len(output.Columns))
+	}
+
+	// Check first column
+	if output.Columns[0].Name != "id" {
+		t.Errorf("expected column name 'id', got '%s'", output.Columns[0].Name)
+	}
+	if output.Columns[0].Type != "int" {
+		t.Errorf("expected type 'int', got '%s'", output.Columns[0].Type)
+	}
+	if output.Columns[0].Key != "PRI" {
+		t.Errorf("expected key 'PRI', got '%s'", output.Columns[0].Key)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolDescribeTableMissingDatabase(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, _, err := toolDescribeTable(ctx, &mcp.CallToolRequest{}, DescribeTableInput{
+		Database: "",
+		Table:    "users",
+	})
+
+	if err == nil {
+		t.Error("expected error for missing database")
+	}
+	if err.Error() != "database is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolDescribeTableMissingTable(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, _, err := toolDescribeTable(ctx, &mcp.CallToolRequest{}, DescribeTableInput{
+		Database: "testdb",
+		Table:    "",
+	})
+
+	if err == nil {
+		t.Error("expected error for missing table")
+	}
+	if err.Error() != "table is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolRunQuerySelectSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"id", "name", "email"}).
+		AddRow(1, "Alice", "alice@example.com").
+		AddRow(2, "Bob", "bob@example.com")
+
+	mock.ExpectQuery("SELECT \\* FROM users").WillReturnRows(rows)
+
+	ctx := context.Background()
+	_, output, err := toolRunQuery(ctx, &mcp.CallToolRequest{}, RunQueryInput{
+		SQL: "SELECT * FROM users",
+	})
+
+	if err != nil {
+		t.Fatalf("toolRunQuery failed: %v", err)
+	}
+
+	if len(output.Columns) != 3 {
+		t.Errorf("expected 3 columns, got %d", len(output.Columns))
+	}
+
+	if len(output.Rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(output.Rows))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolRunQueryEmptySQL(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, _, err := toolRunQuery(ctx, &mcp.CallToolRequest{}, RunQueryInput{
+		SQL: "",
+	})
+
+	if err == nil {
+		t.Error("expected error for empty SQL")
+	}
+	if err.Error() != "sql is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolRunQueryBlockedQuery(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, _, err := toolRunQuery(ctx, &mcp.CallToolRequest{}, RunQueryInput{
+		SQL: "DROP TABLE users",
+	})
+
+	if err == nil {
+		t.Error("expected error for blocked query")
+	}
+
+	// Should be rejected by validator
+	if err.Error() == "sql is required" {
+		t.Error("should fail validation, not be empty")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolRunQueryWithMaxRows(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"id"}).
+		AddRow(1).
+		AddRow(2).
+		AddRow(3).
+		AddRow(4).
+		AddRow(5)
+
+	mock.ExpectQuery("SELECT id FROM numbers").WillReturnRows(rows)
+
+	ctx := context.Background()
+	maxRows := 3
+	_, output, err := toolRunQuery(ctx, &mcp.CallToolRequest{}, RunQueryInput{
+		SQL:     "SELECT id FROM numbers",
+		MaxRows: &maxRows,
+	})
+
+	if err != nil {
+		t.Fatalf("toolRunQuery failed: %v", err)
+	}
+
+	// Should be limited to 3 rows
+	if len(output.Rows) != 3 {
+		t.Errorf("expected 3 rows (limited), got %d", len(output.Rows))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolPingSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mock.ExpectPing()
+
+	ctx := context.Background()
+	_, output, err := toolPing(ctx, &mcp.CallToolRequest{}, PingInput{})
+
+	if err != nil {
+		t.Fatalf("toolPing failed: %v", err)
+	}
+
+	if !output.Success {
+		t.Error("expected ping to succeed")
+	}
+	if output.Message != "pong" {
+		t.Errorf("expected message 'pong', got '%s'", output.Message)
+	}
+	if output.LatencyMs < 0 {
+		t.Error("latency should be non-negative")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolListConnectionsNoManager(t *testing.T) {
+	// Save and restore global state
+	oldConnManager := connManager
+	defer func() { connManager = oldConnManager }()
+
+	connManager = nil
+
+	ctx := context.Background()
+	_, _, err := toolListConnections(ctx, &mcp.CallToolRequest{}, ListConnectionsInput{})
+
+	if err == nil {
+		t.Error("expected error when connManager is nil")
+	}
+	if err.Error() != "connection manager not initialized" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestToolListConnectionsSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	// Set up connection manager
+	cm := NewConnectionManager()
+	cm.connections["test1"] = db
+	cm.configs["test1"] = config.ConnectionConfig{Name: "test1", DSN: "user:pass@tcp(localhost)/db1", Description: "Test 1"}
+	cm.connections["test2"] = db
+	cm.configs["test2"] = config.ConnectionConfig{Name: "test2", DSN: "user:pass@tcp(localhost)/db2", Description: "Test 2"}
+	cm.activeConn = "test1"
+	connManager = cm
+
+	ctx := context.Background()
+	_, output, err := toolListConnections(ctx, &mcp.CallToolRequest{}, ListConnectionsInput{})
+
+	if err != nil {
+		t.Fatalf("toolListConnections failed: %v", err)
+	}
+
+	if len(output.Connections) != 2 {
+		t.Errorf("expected 2 connections, got %d", len(output.Connections))
+	}
+	if output.Active != "test1" {
+		t.Errorf("expected active 'test1', got '%s'", output.Active)
+	}
+
+	_ = mock
+}
+
+func TestToolUseConnectionNoManager(t *testing.T) {
+	oldConnManager := connManager
+	defer func() { connManager = oldConnManager }()
+
+	connManager = nil
+
+	ctx := context.Background()
+	_, _, err := toolUseConnection(ctx, &mcp.CallToolRequest{}, UseConnectionInput{Name: "test"})
+
+	if err == nil {
+		t.Error("expected error when connManager is nil")
+	}
+}
+
+func TestToolUseConnectionEmptyName(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	cm := NewConnectionManager()
+	cm.connections["test"] = db
+	cm.configs["test"] = config.ConnectionConfig{Name: "test", DSN: "user:pass@tcp(localhost)/db", Description: "Test"}
+	cm.activeConn = "test"
+	connManager = cm
+
+	ctx := context.Background()
+	_, _, err := toolUseConnection(ctx, &mcp.CallToolRequest{}, UseConnectionInput{Name: ""})
+
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
+	if err.Error() != "connection name is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_ = mock
+}
+
+func TestToolUseConnectionSuccess(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	// Expect DATABASE() query after switch
+	mock.ExpectQuery("SELECT DATABASE\\(\\)").WillReturnRows(
+		sqlmock.NewRows([]string{"DATABASE()"}).AddRow("testdb"),
+	)
+
+	cm := NewConnectionManager()
+	cm.connections["conn1"] = db
+	cm.configs["conn1"] = config.ConnectionConfig{Name: "conn1", DSN: "user:pass@tcp(localhost)/db1", Description: "Conn 1"}
+	cm.connections["conn2"] = db
+	cm.configs["conn2"] = config.ConnectionConfig{Name: "conn2", DSN: "user:pass@tcp(localhost)/db2", Description: "Conn 2"}
+	cm.activeConn = "conn1"
+	connManager = cm
+
+	ctx := context.Background()
+	_, output, err := toolUseConnection(ctx, &mcp.CallToolRequest{}, UseConnectionInput{Name: "conn2"})
+
+	if err != nil {
+		t.Fatalf("toolUseConnection failed: %v", err)
+	}
+
+	if !output.Success {
+		t.Error("expected success")
+	}
+	if output.Active != "conn2" {
+		t.Errorf("expected active 'conn2', got '%s'", output.Active)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestToolUseConnectionNotFound(t *testing.T) {
+	mock, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	cm := NewConnectionManager()
+	cm.connections["conn1"] = db
+	cm.configs["conn1"] = config.ConnectionConfig{Name: "conn1", DSN: "user:pass@tcp(localhost)/db1", Description: "Conn 1"}
+	cm.activeConn = "conn1"
+	connManager = cm
+
+	ctx := context.Background()
+	_, output, err := toolUseConnection(ctx, &mcp.CallToolRequest{}, UseConnectionInput{Name: "nonexistent"})
+
+	// Should not return error, but output.Success should be false
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.Success {
+		t.Error("expected success to be false")
+	}
+
+	_ = mock
+}
+


### PR DESCRIPTION
- Add logging_test.go: tests for QueryTimer, AuditLogger, log entries
- Add connection_test.go: tests for ConnectionManager, multi-DSN support
- Add tools_test.go: tests for MCP tool handlers using sqlmock

Coverage for cmd/mysql-mcp-server increased from 0% to 17.3%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add comprehensive unit tests for `cmd/mysql-mcp-server` covering connection management, logging/auditing, and MCP tool handlers using sqlmock, including concurrency and error paths.
> 
> - **Tests added in `cmd/mysql-mcp-server`**:
>   - **Connection management (`connection_test.go`)**:
>     - Validate `NewConnectionManager`, `GetActive`/`GetActiveDB`, `SetActive`, `List` (with DSN masking), and `Close`.
>     - Handle multiple connections and `getDB` behavior with/without manager.
>     - Concurrency checks for reads and `SetActive`.
>   - **Logging & auditing (`logging_test.go`)**:
>     - `QueryTimer` timing and success/error logging to stderr.
>     - `AuditLogger` enabled/disabled modes, invalid path handling, concurrent `Log` writes, and file output validation.
>     - JSON (de)serialization for `LogEntry` and `AuditEntry` (including error field).
>   - **MCP tools (`tools_test.go`)**:
>     - `toolListDatabases`, `toolListTables`, `toolDescribeTable` success/validation.
>     - `toolRunQuery` select results, `MaxRows` limiting, and blocked/empty SQL validation.
>     - `toolPing` latency/success; `toolListConnections` and `toolUseConnection` success and error cases (no manager, not found).
>     - Uses `sqlmock` and controlled globals for isolation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d2e9c64ad32b8d011a51e277ccfce04703e811b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->