### PR TITLE
Fix test issues: properly check mock expectations and improve log cap…

### DIFF
--- a/cmd/mysql-mcp-server/connection_test.go
+++ b/cmd/mysql-mcp-server/connection_test.go
@@ -69,11 +69,8 @@ func TestConnectionManagerWithMockDB(t *testing.T) {
 	}
 	defer mockDB.Close()
 
-	// Expect ping
-	mock.ExpectPing()
-
 	cm := NewConnectionManager()
-	
+
 	// Manually add the mock connection (bypassing AddConnectionWithPoolConfig)
 	cm.connections["test"] = mockDB
 	cm.configs["test"] = config.ConnectionConfig{
@@ -138,9 +135,6 @@ func TestConnectionManagerMultipleConnections(t *testing.T) {
 	}
 	defer mockDB2.Close()
 
-	mock1.ExpectPing()
-	mock2.ExpectPing()
-
 	cm := NewConnectionManager()
 
 	// Add connections manually
@@ -186,8 +180,12 @@ func TestConnectionManagerMultipleConnections(t *testing.T) {
 	}
 
 	cm.Close()
-	_ = mock1.ExpectationsWereMet()
-	_ = mock2.ExpectationsWereMet()
+	if err := mock1.ExpectationsWereMet(); err != nil {
+		t.Errorf("mock1 unfulfilled expectations: %v", err)
+	}
+	if err := mock2.ExpectationsWereMet(); err != nil {
+		t.Errorf("mock2 unfulfilled expectations: %v", err)
+	}
 }
 
 func TestGetDBWithConnManager(t *testing.T) {
@@ -266,13 +264,11 @@ func TestConnectionConfigStruct(t *testing.T) {
 
 func TestConnectionManagerConcurrency(t *testing.T) {
 	// Create mock database
-	mockDB, mock, err := sqlmock.New()
+	mockDB, _, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create mock: %v", err)
 	}
 	defer mockDB.Close()
-
-	mock.ExpectPing()
 
 	cm := NewConnectionManager()
 	cm.connections["test"] = mockDB
@@ -306,4 +302,3 @@ func TestConnectionManagerConcurrency(t *testing.T) {
 		<-done
 	}
 }
-


### PR DESCRIPTION
…ture

- connection_test.go: Fix TestConnectionManagerMultipleConnections to properly check ExpectationsWereMet() errors instead of silently discarding them with blank identifiers

- logging_test.go: Improve log output capture by also redirecting the standard log package output, and add proper error checking for empty output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens test robustness by checking sqlmock ExpectationsWereMet and capturing standard logger output in logging tests, while removing unused ping expectations.
> 
> - **Tests**:
>   - **Connection manager (`cmd/mysql-mcp-server/connection_test.go`)**:
>     - Validate `sqlmock` expectations via explicit `ExpectationsWereMet()` checks (including multi-connection test).
>     - Remove unused `ExpectPing()` expectations and related mock variables.
>   - **Logging (`cmd/mysql-mcp-server/logging_test.go`)**:
>     - Capture standard library logger output with `log.SetOutput` during tests and restore afterward.
>     - Strengthen assertions to verify non-empty output and presence of key substrings for success/error logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 126f0c3614526883ca4018fe12628203beb64319. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->