### PR TITLE
fix: ensure Docker cleanup runs even when integration tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,15 +71,19 @@ integration:
 # Integration tests with Docker Compose
 test-integration: test-mysql-up
 	@echo "$(BLUE)🐋 Running full integration test suite...$(RESET)"
-	MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
-		go test -tags=integration -v ./...
-	@$(MAKE) test-mysql-down
+	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
+		go test -tags=integration -v ./...; \
+		TEST_EXIT=$$?; \
+		docker-compose -f docker-compose.test.yml down; \
+		exit $$TEST_EXIT
 
 test-integration-80: test-mysql-up
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 8.0...$(RESET)"
-	MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
-		go test -tags=integration -v ./tests/integration/...
-	@$(MAKE) test-mysql-down
+	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
+		go test -tags=integration -v ./tests/integration/...; \
+		TEST_EXIT=$$?; \
+		docker-compose -f docker-compose.test.yml down; \
+		exit $$TEST_EXIT
 
 test-integration-84:
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 8.4...$(RESET)"


### PR DESCRIPTION
The test-integration and test-integration-80 targets used separate make commands for cleanup, which never ran if tests failed. This change uses shell command chaining to capture the exit code, run cleanup, then exit with the original code - matching the pattern in test-integration-84/90.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `test-integration` and `test-integration-80` to always run `docker-compose down` and exit with original test status.
> 
> - **Makefile**:
>   - **Integration test targets**:
>     - Update `test-integration` and `test-integration-80` to capture test exit code, run `docker-compose -f docker-compose.test.yml down`, then exit with the original status (aligns with `test-integration-84/90`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d508e02ce67996d252595a24921a66c7a89b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->