### PR TITLE
feat: use Docker healthchecks instead of fixed sleep delays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test-integration-80: test-mysql-up
 
 test-integration-84:
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 8.4...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait mysql84
+	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql84
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3307)/testdb?parseTime=true" \
 		go test -tags=integration -v ./tests/integration/...; \
 		TEST_EXIT=$$?; \
@@ -96,7 +96,7 @@ test-integration-84:
 
 test-integration-90:
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 9.0...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait mysql90
+	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql90
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3308)/testdb?parseTime=true" \
 		go test -tags=integration -v ./tests/integration/...; \
 		TEST_EXIT=$$?; \
@@ -113,7 +113,7 @@ test-integration-all:
 # Docker Compose helpers for test databases
 test-mysql-up:
 	@echo "$(CYAN)🐳 Starting MySQL test containers...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait mysql80
+	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql80
 
 test-mysql-down:
 	@echo "$(CYAN)🐳 Stopping MySQL test containers...$(RESET)"
@@ -121,7 +121,7 @@ test-mysql-down:
 
 test-mysql-all-up:
 	@echo "$(CYAN)🐳 Starting all MySQL test containers...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait
+	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 90
 
 test-mysql-logs:
 	docker-compose -f docker-compose.test.yml logs -f


### PR DESCRIPTION
## Summary

Replace fixed `sleep 15/20` delays with Docker Compose `--wait` flag which waits for container healthchecks to pass before proceeding.

## Changes

| Target | Before | After |
|--------|--------|-------|
| `test-mysql-up` | `sleep 15` | `--wait` |
| `test-mysql-all-up` | `sleep 20` | `--wait` |
| `test-integration-84` | `sleep 15` | `--wait` |
| `test-integration-90` | `sleep 15` | `--wait` |

## How it works

- `docker-compose up -d --wait` starts containers and waits for their healthchecks to pass
- The healthchecks in `docker-compose.test.yml` use `mysqladmin ping` to verify MySQL is ready
- Tests proceed immediately when MySQL is accepting connections

## Benefits

- ✅ **Faster**: Proceeds immediately when MySQL is ready (typically 5-8 seconds vs fixed 15-20)
- ✅ **Reliable**: Verifies actual MySQL connectivity instead of guessing
- ✅ **Self-adjusting**: Works correctly on fast and slow machines

## Requirements

- Docker Compose v2.1+ (widely available, default since 2022)

Closes #15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `docker-compose up -d --wait` (with timeouts) instead of fixed `sleep` across MySQL test container and integration targets.
> 
> - **Makefile**:
>   - **Integration targets**: `test-integration-84`, `test-integration-90` now start `mysql84`/`mysql90` with `docker-compose up -d --wait --wait-timeout 60` instead of `sleep`.
>   - **Test DB helpers**: `test-mysql-up` uses `--wait --wait-timeout 60` for `mysql80`; `test-mysql-all-up` uses `--wait --wait-timeout 90` for all containers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe11ae67f917daf88624f0188cc5b285f145f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->