### PR TITLE
fix: Update Makefile to use Docker Compose V2 syntax

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,4 @@ examples/
 LICENSE
 *.log
 tmp/
+

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test-integration: test-mysql-up
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
 		go test -tags=integration -v ./...; \
 		TEST_EXIT=$$?; \
-		docker-compose -f docker-compose.test.yml down; \
+		docker compose -f docker-compose.test.yml down; \
 		exit $$TEST_EXIT
 
 test-integration-80: test-mysql-up
@@ -82,25 +82,25 @@ test-integration-80: test-mysql-up
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3306)/testdb?parseTime=true" \
 		go test -tags=integration -v ./tests/integration/...; \
 		TEST_EXIT=$$?; \
-		docker-compose -f docker-compose.test.yml down; \
+		docker compose -f docker-compose.test.yml down; \
 		exit $$TEST_EXIT
 
 test-integration-84:
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 8.4...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql84
+	@docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql84
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3307)/testdb?parseTime=true" \
 		go test -tags=integration -v ./tests/integration/...; \
 		TEST_EXIT=$$?; \
-		docker-compose -f docker-compose.test.yml stop mysql84; \
+		docker compose -f docker-compose.test.yml stop mysql84; \
 		exit $$TEST_EXIT
 
 test-integration-90:
 	@echo "$(BLUE)🐋 Running integration tests against MySQL 9.0...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql90
+	@docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql90
 	@MYSQL_TEST_DSN="root:testpass@tcp(localhost:3308)/testdb?parseTime=true" \
 		go test -tags=integration -v ./tests/integration/...; \
 		TEST_EXIT=$$?; \
-		docker-compose -f docker-compose.test.yml stop mysql90; \
+		docker compose -f docker-compose.test.yml stop mysql90; \
 		exit $$TEST_EXIT
 
 test-integration-all:
@@ -113,18 +113,18 @@ test-integration-all:
 # Docker Compose helpers for test databases
 test-mysql-up:
 	@echo "$(CYAN)🐳 Starting MySQL test containers...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql80
+	@docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 60 mysql80
 
 test-mysql-down:
 	@echo "$(CYAN)🐳 Stopping MySQL test containers...$(RESET)"
-	docker-compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml down
 
 test-mysql-all-up:
 	@echo "$(CYAN)🐳 Starting all MySQL test containers...$(RESET)"
-	@docker-compose -f docker-compose.test.yml up -d --wait --wait-timeout 90
+	@docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 90
 
 test-mysql-logs:
-	docker-compose -f docker-compose.test.yml logs -f
+	docker compose -f docker-compose.test.yml logs -f
 
 # ----------------------------------------
 # Code Quality

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -93,3 +93,4 @@ networks:
   default:
     name: mysql-mcp-test-network
 
+


### PR DESCRIPTION
## Summary

Updates the Makefile to use `docker compose` (Docker Compose V2) instead of the deprecated `docker-compose` command.

## Changes

- Replace all `docker-compose` with `docker compose` in Makefile
- Minor whitespace cleanup in `.dockerignore` and `docker-compose.test.yml`

## Problem

On systems with Docker Desktop or modern Docker installations, the standalone `docker-compose` command is deprecated/unavailable. This caused:

```
make test-mysql-all-up
🐳 Starting all MySQL test containers...
make: docker-compose: No such file or directory
make: *** [test-mysql-all-up] Error 1
```

## Testing

Verified locally:
- `make test-mysql-all-up` ✅
- `make test-mysql-down` ✅
- MCP server REST API tests ✅

Fixes #33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes test tooling to Docker Compose V2 and does minor whitespace cleanup.
> 
> - Replace `docker-compose` with `docker compose` across Makefile integration/test targets (`test-integration*`, `test-mysql-*`, logs/down steps)
> - No logic changes to test flow; only command invocations updated
> - Minor trailing newline/whitespace adjustments in `.dockerignore` and `docker-compose.test.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fb0e2c109678cdd6dd0d7b29d11c47580ffac19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->