### PR TITLE
docs: Fix README inconsistencies and add missing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div align="center">
   <img src="./MysqlMCPServerBanner.png" alt="MySQL MCP Server Banner" width="800"/>
   
-  [![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/askdba/mysql-mcp-server/releases)
-  [![Go](https://img.shields.io/badge/go-1.25+-00ADD8.svg)](https://golang.org/)
+  [![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/askdba/mysql-mcp-server/releases)
+  [![Go](https://img.shields.io/badge/go-1.24+-00ADD8.svg)](https://golang.org/)
   [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 </div>
 
@@ -97,6 +97,9 @@ Environment variables:
 | MYSQL_MAX_OPEN_CONNS | No | 10 | Max open database connections |
 | MYSQL_MAX_IDLE_CONNS | No | 5 | Max idle database connections |
 | MYSQL_CONN_MAX_LIFETIME_MINUTES | No | 30 | Connection max lifetime in minutes |
+| MYSQL_CONN_MAX_IDLE_TIME_MINUTES | No | 5 | Max idle time before connection is closed |
+| MYSQL_PING_TIMEOUT_SECONDS | No | 5 | Database ping/health check timeout |
+| MYSQL_HTTP_REQUEST_TIMEOUT_SECONDS | No | 60 | HTTP request timeout in REST API mode |
 
 ### Multi-DSN Configuration
 
@@ -149,17 +152,28 @@ mysql-mcp-server --version
 
 Output:
 ```
-mysql-mcp-server v1.1.0
-  Build time: 2025-01-15T10:30:00Z
-  Git commit: abc1234
+mysql-mcp-server v1.3.1
+  Build time: 2025-12-21T11:43:11Z
+  Git commit: a1b2c3d
 ```
 
 ## Claude Desktop Integration
 
-Edit:
+Edit your Claude Desktop configuration file:
 
+**macOS:**
 ```
 ~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+**Windows:**
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+**Linux:**
+```
+~/.config/Claude/claude_desktop_config.json
 ```
 
 Add:
@@ -710,10 +724,9 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ### Docker Compose
 
 ```yaml
-version: "3.9"
 services:
   mysql:
-    image: mysql:8.0.36
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: testdb


### PR DESCRIPTION
## Summary

Fixes multiple documentation issues in README.md.

## Changes

### Issue #29 - Version/badge inconsistencies
- ✅ Update version badge: `1.3.0` → `1.3.1`
- ✅ Fix Go version badge: `1.25+` → `1.24+` (Go 1.25 doesn't exist)
- ✅ Update version example output to current version
- ✅ Remove deprecated Docker Compose `version` field
- ✅ Update Docker Compose example to MySQL 8.4

### Issue #30 - Missing environment variables
Added documentation for:
| Variable | Default | Description |
|----------|---------|-------------|
| `MYSQL_CONN_MAX_IDLE_TIME_MINUTES` | 5 | Max idle time before connection is closed |
| `MYSQL_PING_TIMEOUT_SECONDS` | 5 | Database ping/health check timeout |
| `MYSQL_HTTP_REQUEST_TIMEOUT_SECONDS` | 60 | HTTP request timeout in REST API mode |

### Issue #32 - Claude Desktop config paths
Added configuration paths for all platforms:
- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
- **Linux:** `~/.config/Claude/claude_desktop_config.json`

## Files Changed
- `README.md`

Fixes #29, #30, #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up and completes README documentation.
> 
> - Updates badges to `version-1.3.1` and `go-1.24+`; refreshes `--version` output example
> - Documents new env vars: `MYSQL_CONN_MAX_IDLE_TIME_MINUTES`, `MYSQL_PING_TIMEOUT_SECONDS`, `MYSQL_HTTP_REQUEST_TIMEOUT_SECONDS`
> - Adds Claude Desktop config paths for macOS, Windows, and Linux with edit guidance
> - Updates Docker Compose example: remove `version` field and bump MySQL image to `mysql:8.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 422999471e77912da34af503c25cd9b03c708979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->