### PR TITLE
docs: Add Cursor IDE integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,64 @@ Add:
 
 Restart Claude Desktop.
 
+## Cursor IDE Integration
+
+Cursor IDE supports the Model Context Protocol (MCP). Configure it to use mysql-mcp-server:
+
+Edit your Cursor MCP configuration file:
+
+**macOS:**
+```
+~/.cursor/mcp.json
+```
+
+**Windows:**
+```
+%APPDATA%\Cursor\mcp.json
+```
+
+**Linux:**
+```
+~/.config/Cursor/mcp.json
+```
+
+Add:
+
+```json
+{
+  "mcpServers": {
+    "mysql": {
+      "command": "mysql-mcp-server",
+      "env": {
+        "MYSQL_DSN": "root:password@tcp(127.0.0.1:3306)/mydb?parseTime=true",
+        "MYSQL_MAX_ROWS": "200",
+        "MYSQL_MCP_EXTENDED": "1"
+      }
+    }
+  }
+}
+```
+
+**With Docker:**
+
+```json
+{
+  "mcpServers": {
+    "mysql": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "MYSQL_DSN=root:password@tcp(host.docker.internal:3306)/mydb?parseTime=true",
+        "-e", "MYSQL_MCP_EXTENDED=1",
+        "ghcr.io/askdba/mysql-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+Restart Cursor after saving the configuration.
+
 ## MCP Tools
 
 ### list_databases


### PR DESCRIPTION
## Summary

Adds documentation for integrating mysql-mcp-server with Cursor IDE.

## Changes

- Add new "Cursor IDE Integration" section to README
- Include configuration file paths for all platforms:
  - macOS: `~/.cursor/mcp.json`
  - Windows: `%APPDATA%\Cursor\mcp.json`
  - Linux: `~/.config/Cursor/mcp.json`
- Add binary configuration example
- Add Docker configuration example
- Note restart requirement

## Why

Cursor IDE now supports MCP (Model Context Protocol). Since mysql-mcp-server uses the official MCP SDK with stdio transport, it's fully compatible with Cursor.

## Files Changed

- `README.md`

Fixes #39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for integrating `mysql-mcp-server` with Cursor IDE.
> 
> - New **Cursor IDE Integration** section in `README.md` with MCP config file paths for macOS (`~/.cursor/mcp.json`), Windows (`%APPDATA%\Cursor\mcp.json`), and Linux (`~/.config/Cursor/mcp.json`)
> - Provides JSON examples for running `mysql-mcp-server` directly (`command: "mysql-mcp-server"`) with `MYSQL_DSN`, `MYSQL_MAX_ROWS`, `MYSQL_MCP_EXTENDED`, and via Docker (`command: "docker"`, `args: [...]`)
> - Notes to restart Cursor after saving configuration
> - Scope: documentation only; code unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90583c8ab03e85c543f53d7fa2dabf0a37d2c164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->