### PR TITLE
fix: Use configurable ping timeout instead of hardcoded 5s

### DIFF
--- a/cmd/mysql-mcp-server/main.go
+++ b/cmd/mysql-mcp-server/main.go
@@ -34,6 +34,7 @@ var (
 	// Convenience aliases from config (for tool access)
 	maxRows      int
 	queryTimeout time.Duration
+	pingTimeout  time.Duration
 	extendedMode bool
 	jsonLogging  bool
 
@@ -76,6 +77,7 @@ func main() {
 	// Set convenience aliases
 	maxRows = cfg.MaxRows
 	queryTimeout = cfg.QueryTimeout
+	pingTimeout = cfg.PingTimeout
 	extendedMode = cfg.ExtendedMode
 	jsonLogging = cfg.JSONLogging
 

--- a/cmd/mysql-mcp-server/tools.go
+++ b/cmd/mysql-mcp-server/tools.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/askdba/mysql-mcp-server/internal/util"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -311,7 +310,7 @@ func toolPing(
 	input PingInput,
 ) (*mcp.CallToolResult, PingOutput, error) {
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, pingTimeout)
 	defer cancel()
 
 	start := NewQueryTimer("ping")

--- a/cmd/mysql-mcp-server/tools_test.go
+++ b/cmd/mysql-mcp-server/tools_test.go
@@ -23,18 +23,21 @@ func setupMockDB(t *testing.T) (sqlmock.Sqlmock, func()) {
 	oldDB := db
 	oldMaxRows := maxRows
 	oldQueryTimeout := queryTimeout
+	oldPingTimeout := pingTimeout
 
 	// Set up global state
 	db = mockDB
 	connManager = nil
 	maxRows = 1000
 	queryTimeout = 30 * time.Second
+	pingTimeout = time.Duration(config.DefaultPingTimeoutSecs) * time.Second
 
 	cleanup := func() {
 		connManager = oldConnManager
 		db = oldDB
 		maxRows = oldMaxRows
 		queryTimeout = oldQueryTimeout
+		pingTimeout = oldPingTimeout
 		mockDB.Close()
 	}
 


### PR DESCRIPTION
## Summary

Fixes the hardcoded 5-second timeout in `toolPing` to use the configurable `MYSQL_PING_TIMEOUT_SECONDS` environment variable.

## Problem

The `toolPing` function used a hardcoded `5*time.Second` timeout:

```go
ctx, cancel := context.WithTimeout(ctx, 5*time.Second)  // hardcoded!
```

Meanwhile, `cfg.PingTimeout` (from `MYSQL_PING_TIMEOUT_SECONDS`) was only used for connection validation, not for the ping tool.

## Solution

- Add `pingTimeout` global variable (like `queryTimeout`)
- Initialize from `cfg.PingTimeout` in `main()`
- Use `pingTimeout` in `toolPing` instead of hardcoded value
- Update test setup to initialize `pingTimeout`

## Changes

| File | Change |
|------|--------|
| `main.go` | Add `pingTimeout` variable and initialization |
| `tools.go` | Use `pingTimeout` instead of `5*time.Second` |
| `tools_test.go` | Add `pingTimeout` to test setup |

## Testing

- ✅ `TestToolPingSuccess` passes
- ✅ All unit tests pass
- ✅ All internal tests pass
- ✅ All security tests pass

## Backward Compatibility

Default timeout remains **5 seconds** - existing behavior unchanged unless user sets `MYSQL_PING_TIMEOUT_SECONDS`.

## Usage

```bash
# Custom ping timeout (e.g., 10 seconds)
export MYSQL_PING_TIMEOUT_SECONDS=10
```

Fixes #37

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the ping tool respect the configured timeout instead of a hardcoded value.
> 
> - Adds `pingTimeout` global alias and initializes it from `cfg.PingTimeout` in `main.go`
> - Replaces `5*time.Second` with `pingTimeout` in `toolPing` (`tools.go`)
> - Updates test setup to set and restore `pingTimeout` (`tools_test.go`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed06d0007b32bfecc17cec41cc6db9811e0d8f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->