### PR TITLE
ci: Automate README version updates in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,10 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.version }}
           # VERSION has been validated to only contain safe characters (alphanumeric, dots, hyphens)
-          # Update version badge
-          sed -i "s/version-[0-9.]*-blue/version-${VERSION}-blue/g" README.md
-          # Update version example (match pattern like "mysql-mcp-server vX.Y.Z")
-          sed -i "s/mysql-mcp-server v[0-9.]*/mysql-mcp-server v${VERSION}/g" README.md
+          # Update version badge - pattern must match pre-release versions like 1.2.3-beta.1
+          sed -i "s/version-[0-9a-zA-Z.-]*-blue/version-${VERSION}-blue/g" README.md
+          # Update version example (match pattern like "mysql-mcp-server vX.Y.Z" or "mysql-mcp-server vX.Y.Z-beta.1")
+          sed -i "s/mysql-mcp-server v[0-9a-zA-Z.-]*/mysql-mcp-server v${VERSION}/g" README.md
           echo "Updated README.md with version $VERSION"
           git diff README.md || echo "No changes to README.md"
 


### PR DESCRIPTION
## Summary

Automates README.md version updates as part of the release pipeline, eliminating manual post-release updates.

## Changes

Added new `update-readme` job to `.github/workflows/release.yml` that:

1. **Extracts version** from git tag (`v1.4.0` → `1.4.0`)
2. **Updates version badge** using sed
3. **Updates version example** in the Version Information section
4. **Commits and pushes** to main with `[skip ci]` flag

## Release Pipeline Flow

```
Tag pushed (v1.4.0)
        ↓
  update-readme    ← NEW: Updates README
        ↓
   goreleaser      ← Builds binaries
        ↓
     docker        ← Builds images
```

## What Gets Updated

| Element | Before | After |
|---------|--------|-------|
| Version badge | `version-1.3.1-blue` | `version-1.4.0-blue` |
| Version example | `mysql-mcp-server v1.3.1` | `mysql-mcp-server v1.4.0` |

## Testing

Tested sed patterns locally:
```
✅ version-1.3.1-blue → version-1.4.0-blue
✅ mysql-mcp-server v1.3.1 → mysql-mcp-server v1.4.0
```

## Files Changed

- `.github/workflows/release.yml`

Fixes #38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates README updates in the release workflow and ensures builds run from the tagged commit.
> 
> - Adds `update-readme` job (after `goreleaser`) to extract/validate version from tag, update README badge/examples via `sed`, and commit to `main` with `[skip ci]`
> - `docker` job now explicitly checks out the triggering tag; `goreleaser` checkout clarified to use the tagged commit for version extraction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 488ccce4ff64b747c761ab48bc653b9fe86743e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->