### PR TITLE
refactor: Phase out deprecated global db variable

### DIFF
--- a/cmd/mysql-mcp-server/connection.go
+++ b/cmd/mysql-mcp-server/connection.go
@@ -137,11 +137,11 @@ func (cm *ConnectionManager) Close() {
 }
 
 // getDB returns the active database connection in a thread-safe manner.
-// This should be used instead of accessing the global db variable directly
-// to avoid data races when connections are switched.
+// All database access should go through this function to ensure proper
+// connection management and avoid data races when connections are switched.
 func getDB() *sql.DB {
-	if connManager != nil {
-		return connManager.GetActiveDB()
+	if connManager == nil {
+		panic("getDB called before connManager initialized")
 	}
-	return db
+	return connManager.GetActiveDB()
 }

--- a/cmd/mysql-mcp-server/connection_test.go
+++ b/cmd/mysql-mcp-server/connection_test.go
@@ -198,10 +198,8 @@ func TestGetDBWithConnManager(t *testing.T) {
 
 	// Save and restore global state
 	oldConnManager := connManager
-	oldDB := db
 	defer func() {
 		connManager = oldConnManager
-		db = oldDB
 	}()
 
 	// Set up connection manager
@@ -217,31 +215,24 @@ func TestGetDBWithConnManager(t *testing.T) {
 	}
 }
 
-func TestGetDBWithoutConnManager(t *testing.T) {
-	// Create mock database
-	mockDB, _, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("failed to create mock: %v", err)
-	}
-	defer mockDB.Close()
-
+func TestGetDBWithoutConnManagerPanics(t *testing.T) {
 	// Save and restore global state
 	oldConnManager := connManager
-	oldDB := db
 	defer func() {
 		connManager = oldConnManager
-		db = oldDB
 	}()
 
-	// Set global db, no connection manager
+	// Set connManager to nil
 	connManager = nil
-	db = mockDB
 
-	// getDB should return global db
-	result := getDB()
-	if result != mockDB {
-		t.Error("getDB should return global db when connManager is nil")
-	}
+	// getDB should panic when connManager is nil
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("getDB should panic when connManager is nil")
+		}
+	}()
+
+	getDB() // This should panic
 }
 
 func TestConnectionConfigStruct(t *testing.T) {

--- a/cmd/mysql-mcp-server/main.go
+++ b/cmd/mysql-mcp-server/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -37,10 +36,6 @@ var (
 	pingTimeout  time.Duration
 	extendedMode bool
 	jsonLogging  bool
-
-	// Deprecated: Use connManager.GetActiveDB() instead.
-	// Kept for backward compatibility during transition.
-	db *sql.DB
 )
 
 // ===== Main Entry Point =====
@@ -107,8 +102,7 @@ func main() {
 	}
 
 	// Verify we have at least one valid connection
-	db = connManager.GetActiveDB()
-	if db == nil {
+	if connManager.GetActiveDB() == nil {
 		connManager.Close() // Clean up before exit
 		log.Fatalf("config error: no valid MySQL connections available")
 	}


### PR DESCRIPTION
## Summary

Phases out the deprecated global `db` variable and requires all database access to route through `ConnectionManager` via the `getDB()` helper function.

## Changes

### Core Changes
- **main.go**: Removed global `db *sql.DB` variable and `database/sql` import
- **connection.go**: Updated `getDB()` to panic if `connManager` is nil (ensures proper initialization)

### Test Updates
- **tools_test.go**: Added `setupMockDBFull()` helper that returns mock DB for tests needing custom connection managers
- **http_test.go**: Added `setupHTTPTestFull()` with same pattern
- **tools_extended_test.go**: Added config import, updated mock setup to use connManager
- **connection_test.go**: Updated `TestGetDBWithoutConnManager` → `TestGetDBWithoutConnManagerPanics` to verify panic behavior

## Before/After

**Before:**
```go
// main.go - DEPRECATED
db *sql.DB  // Global variable that could get stale

// connection.go
func getDB() *sql.DB {
    if connManager != nil {
        return connManager.GetActiveDB()
    }
    return db  // Fallback to potentially stale global
}
```

**After:**
```go
// connection.go - ENFORCED
func getDB() *sql.DB {
    if connManager == nil {
        panic("getDB called before connManager initialized")
    }
    return connManager.GetActiveDB()
}
```

## Why This Matters

1. **Thread Safety**: Direct access to global `db` could cause issues when connections are switched via multi-DSN support
2. **Data Races**: Code using `db` directly instead of `getDB()` may use stale connections
3. **Enforced Correctness**: Panic on nil connManager catches initialization bugs early

## Testing

All tests pass:
```
ok  github.com/askdba/mysql-mcp-server/cmd/mysql-mcp-server
ok  github.com/askdba/mysql-mcp-server/internal/api
ok  github.com/askdba/mysql-mcp-server/internal/config
ok  github.com/askdba/mysql-mcp-server/internal/mysql
ok  github.com/askdba/mysql-mcp-server/internal/util
ok  github.com/askdba/mysql-mcp-server/tests/security
```

Fixes #36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces all direct/global DB access with `ConnectionManager` to ensure safe, consistent connection handling.
> 
> - **Enforce ConnectionManager**: `getDB()` now panics if `connManager` is nil; all DB access routes through `connManager.GetActiveDB()`
> - **Remove global `db`**: Deleted from `main.go` along with unused `database/sql` import; startup verifies an active connection via `connManager`
> - **Test refactors**: New helpers `setupMockDBFull()` and `setupHTTPTestFull()` return `mockDB` + cleanup for composing custom managers; all tests updated to use `connManager` (no `db` fallback) and to assert panic in `TestGetDBWithoutConnManagerPanics`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c489ce2e6ed736cb044f5cc4ca14b3b40de37ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->