### PR TITLE
feat: Add /api/partitions HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@ When rate limited, clients receive HTTP 429 (Too Many Requests) with a `Retry-Af
 | GET | `/api/triggers?database=` | List triggers |
 | GET | `/api/procedures?database=` | List procedures |
 | GET | `/api/functions?database=` | List functions |
+| GET | `/api/partitions?database=&table=` | List table partitions |
 | GET | `/api/size/database?database=` | Database size |
 | GET | `/api/size/tables?database=` | Table sizes |
 | GET | `/api/foreign-keys?database=` | Foreign keys |


### PR DESCRIPTION
## Summary

Adds the missing `/api/partitions` HTTP endpoint for the `list_partitions` MCP tool, bringing REST API parity with the MCP interface.

## Changes

- **http.go**: Add `httpListPartitions` handler
- **http.go**: Register endpoint with extended feature middleware
- **http.go**: Add to API index
- **http_test.go**: Add endpoint test
- **README.md**: Document endpoint in REST API table

## Endpoint

```
GET /api/partitions?database=xxx&table=yyy
```

**Requires:** `MYSQL_MCP_EXTENDED=1`

## Example Response

```json
{
  "success": true,
  "data": {
    "partitions": [
      {
        "name": "p0",
        "method": "RANGE",
        "expression": "year",
        "description": "2020",
        "table_rows": 1000,
        "data_length": 16384
      }
    ]
  }
}
```

## Testing

All tests pass including new `TestHTTPListPartitions`.

Fixes #31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds REST parity for partition listing in extended mode.
> 
> - Introduces `httpListPartitions` handler and registers `GET /api/partitions?database=&table=` with extended feature and required query params
> - Updates API index to include `GET  /api/partitions`
> - Adds unit test `TestHTTPListPartitions` validating handler behavior
> - Documents the endpoint in `README.md` under extended REST API endpoints
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c95c88985cbf722154d1ed3b54198dbac46c4d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->