### PR TITLE
fix(docs): correct config file search paths in architecture diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,14 +237,37 @@ flowchart TB
 
 ### Config File Search Order
 
+The server searches for config files in the following order (first found wins):
+
 ```mermaid
-flowchart LR
-    A["./mysql-mcp-config.yaml"] --> B["./mysql-mcp-config.json"]
-    B --> C["~/.mysql-mcp-config.yaml"]
-    C --> D["~/.mysql-mcp-config.json"]
-    D --> E["~/.config/mysql-mcp/config.yaml"]
-    E --> F["~/.config/mysql-mcp/config.json"]
-    F --> G["First found wins"]
+flowchart TB
+    subgraph "1. Override (Highest Priority)"
+        A["--config flag"]
+        B["MYSQL_MCP_CONFIG env var"]
+    end
+    
+    subgraph "2. Current Directory"
+        C["./mysql-mcp-server.yaml"]
+        D["./mysql-mcp-server.yml"]
+        E["./mysql-mcp-server.json"]
+    end
+    
+    subgraph "3. User Config"
+        F["~/.config/mysql-mcp-server/config.yaml"]
+        G["~/.config/mysql-mcp-server/config.yml"]
+        H["~/.config/mysql-mcp-server/config.json"]
+    end
+    
+    subgraph "4. System Config (Lowest Priority)"
+        I["/etc/mysql-mcp-server/config.yaml"]
+        J["/etc/mysql-mcp-server/config.yml"]
+        K["/etc/mysql-mcp-server/config.json"]
+    end
+    
+    A --> C
+    B --> C
+    C --> D --> E --> F --> G --> H --> I --> J --> K
+    K --> L(["First found wins"])
 ```
 
 ---


### PR DESCRIPTION
## Problem

The config file search order diagram in `docs/architecture.md` had incorrect paths that don't match the actual `FindConfigFile()` implementation:

| Diagram (Wrong) | Actual Code |
|-----------------|-------------|
| `mysql-mcp-config.yaml` | `mysql-mcp-server.yaml` |
| `~/.mysql-mcp-config.yaml` | ❌ doesn't exist |
| `~/.config/mysql-mcp/` | `~/.config/mysql-mcp-server/` |

## Fix

Updated the diagram to match the actual search order from `internal/config/file.go:FindConfigFile()`:

1. `--config` flag or `MYSQL_MCP_CONFIG` env var (override)
2. Current directory: `mysql-mcp-server.{yaml,yml,json}`
3. User config: `~/.config/mysql-mcp-server/config.{yaml,yml,json}`
4. System config: `/etc/mysql-mcp-server/config.{yaml,yml,json}`

## Impact

Users following the old diagram would create config files that the server wouldn't find, causing silent fallback to defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the configuration search order diagram to match the actual `FindConfigFile()` behavior.
> 
> - Replaces incorrect paths (`mysql-mcp-config*`) with `mysql-mcp-server.{yaml,yml,json}` and proper user/system locations: `~/.config/mysql-mcp-server/config.{yaml,yml,json}` and `/etc/mysql-mcp-server/config.{yaml,yml,json}`
> - Adds highest-priority overrides via `--config` and `MYSQL_MCP_CONFIG`
> - Clarifies precedence and "first found wins" in a reorganized `flowchart TB` diagram
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97653e65c7d05ac17f05a650a5c85f1518883456. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->