### PR TITLE
fix: map SSL 'preferred' to 'skip-verify' for Go MySQL driver compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Enable encrypted connections to MySQL servers:
 | `true` | Enable TLS with certificate verification |
 | `false` | Disable TLS (default) |
 | `skip-verify` | Enable TLS without certificate verification (self-signed certs) |
-| `preferred` | Use TLS if available, fall back to unencrypted |
+| `preferred` | Maps to `skip-verify` (Go MySQL driver limitation) |
+
+> **Note:** The Go MySQL driver doesn't support `tls=preferred`. When you specify `preferred`, it is automatically mapped to `skip-verify` to ensure TLS is enabled.
 
 **Environment variable:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -394,7 +394,7 @@ graph TB
     end
     
     subgraph "Connection Security"
-        TLS["TLS/SSL Options<br/>- true: verify certs<br/>- skip-verify: no verify<br/>- preferred: opportunistic"]
+        TLS["TLS/SSL Options<br/>- true: verify certs<br/>- skip-verify: no verify<br/>- preferred: maps to skip-verify"]
         DSNMask["DSN Masking<br/>- Passwords hidden in logs"]
     end
     

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -633,12 +633,12 @@ func TestApplySSLToDSN(t *testing.T) {
 			ssl:      "SKIP-VERIFY",
 			expected: "user:pass@tcp(localhost:3306)/db?tls=skip-verify",
 		},
-		// Preferred
+		// Preferred (maps to skip-verify since go-sql-driver doesn't support tls=preferred)
 		{
-			name:     "ssl preferred",
+			name:     "ssl preferred maps to skip-verify",
 			dsn:      "user:pass@tcp(localhost:3306)/db",
 			ssl:      "preferred",
-			expected: "user:pass@tcp(localhost:3306)/db?tls=preferred",
+			expected: "user:pass@tcp(localhost:3306)/db?tls=skip-verify",
 		},
 		// DSN with existing params
 		{


### PR DESCRIPTION
## Summary

Fixes #65 - The `MYSQL_SSL=preferred` option was documented but didn't work because the Go MySQL driver doesn't support `tls=preferred`.

## Problem

When users set `MYSQL_SSL=preferred`, the driver would ignore the invalid value and connect **without TLS**, causing connection failures on servers that require SSL (like Azure MySQL).

```
Error 3159 (HY000): Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

## Solution

Map `preferred` to `skip-verify` since that's the closest equivalent behavior:
- Enables TLS encryption
- Doesn't require certificate verification (works with self-signed certs)

## Changes

| File | Change |
|------|--------|
| `internal/config/file.go` | Map `preferred` → `skip-verify` in `ApplySSLToDSN()` |
| `internal/config/file_test.go` | Update test to expect `skip-verify` |
| `README.md` | Document the mapping with a note |
| `docs/architecture.md` | Update security diagram |

## Testing

```bash
go test ./internal/config/... -run SSL -v
# All tests pass including: TestApplySSLToDSN/ssl_preferred_maps_to_skip-verify
```

## Workaround (for users on older versions)

```bash
export MYSQL_SSL="skip-verify"  # instead of "preferred"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures TLS is enabled when users specify `MYSQL_SSL=preferred`, aligning with go-sql-driver/mysql support.
> 
> - Map `preferred` → `skip-verify` in `ApplySSLToDSN` (in `internal/config/file.go`), with clarifying comments and preserving existing `tls=` query params
> - Update unit tests in `internal/config/file_test.go` to expect `tls=skip-verify` and adjust test names
> - Revise `README.md` and `docs/architecture.md` to document the mapping and driver limitation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 546c4078ac604749db426cd6bff5d96c9d668688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->