### PR TITLE
fix: resolve linter warnings (errorlint, staticcheck)

### DIFF
--- a/cmd/mysql-mcp-server/token_estimator_test.go
+++ b/cmd/mysql-mcp-server/token_estimator_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -208,7 +209,7 @@ func TestLimitedWriterStopsEarly(t *testing.T) {
 	// Write data that exceeds the limit
 	largeData := strings.Repeat("x", 200)
 	_, err = lw.Write([]byte(largeData))
-	if err != errLimitExceeded {
+	if !errors.Is(err, errLimitExceeded) {
 		t.Fatalf("expected errLimitExceeded, got %v", err)
 	}
 
@@ -229,7 +230,7 @@ func TestLimitedWriterNoAllocationBeyondCap(t *testing.T) {
 	chunk := strings.Repeat("a", 500)
 	for i := 0; i < 20; i++ {
 		_, err := lw.Write([]byte(chunk))
-		if err == errLimitExceeded {
+		if errors.Is(err, errLimitExceeded) {
 			break
 		}
 	}

--- a/cmd/mysql-mcp-server/tool_wrappers_test.go
+++ b/cmd/mysql-mcp-server/tool_wrappers_test.go
@@ -125,7 +125,7 @@ func TestWrapToolWithError(t *testing.T) {
 	wrapped := wrapTool("test_tool", handler)
 	_, _, err = wrapped(context.Background(), nil, mockInput{Value: "test"})
 
-	if err != expectedErr {
+	if !errors.Is(err, expectedErr) {
 		t.Errorf("expected error %v, got %v", expectedErr, err)
 	}
 }

--- a/internal/util/sql_validator.go
+++ b/internal/util/sql_validator.go
@@ -45,10 +45,7 @@ func stripSQLLiterals(s string) string {
 			if b[i] != '\'' {
 				b[i] = ' '
 			}
-			// Backslash escape: \' or \\ etc.
-			if b[i] == ' ' && i > 0 && b[i-1] == '\\' {
-				// already blanked; continue
-			}
+			// Note: Backslash escapes (\' or \\) are already handled by blanking above.
 			// Handle end / doubled quote escape ('')
 			if i < len(b) && s[i] == '\'' {
 				// If doubled quote, keep string mode and skip the next quote.


### PR DESCRIPTION
## Summary

Fixes #58 - Resolves 4 linter warnings that were blocking clean CI runs.

## Issues Fixed

| File | Line | Issue | Fix |
|------|------|-------|-----|
| `token_estimator_test.go` | 211 | errorlint: comparing with != | Use `errors.Is()` |
| `token_estimator_test.go` | 232 | errorlint: comparing with == | Use `errors.Is()` |
| `tool_wrappers_test.go` | 128 | errorlint: comparing with != | Use `errors.Is()` |
| `sql_validator.go` | 49 | SA9003: empty branch | Remove empty if block |

## Changes

### Error Comparisons (errorlint)

Before:
```go
if err != errLimitExceeded {
```

After:
```go
if !errors.Is(err, errLimitExceeded) {
```

### Empty Branch (staticcheck SA9003)

Removed empty if block that did nothing:
```go
// Before: empty branch that just had a comment
if b[i] == ' ' && i > 0 && b[i-1] == '\\' {
    // already blanked; continue
}

// After: comment only (no empty branch)
// Note: Backslash escapes are already handled by blanking above.
```

## Testing

All affected tests pass:
```
=== RUN   TestLimitedWriterStopsEarly
--- PASS
=== RUN   TestLimitedWriterNoAllocationBeyondCap
--- PASS
=== RUN   TestWrapToolWithError
--- PASS
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves linter findings without changing runtime behavior.
> 
> - Update tests in `cmd/mysql-mcp-server/token_estimator_test.go` and `cmd/mysql-mcp-server/tool_wrappers_test.go` to use `errors.Is(...)` instead of direct comparisons, addressing `errorlint` warnings
> - Remove a no-op `if` branch in `internal/util/sql_validator.go`’s `stripSQLLiterals` (SA9003) and replace it with a clarifying comment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6813901a7062322cbd0c9ccb83c673fd38406786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->