### PR TITLE
docs: add v1.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on "Keep a Changelog" and this project follows
+Semantic Versioning.
+
+## v1.5.0 - 2026-01-17
+
+### Added
+- Architecture documentation with diagrams to explain system flows.
+- GitHub issue and PR templates to standardize contributions.
+- SSL/TLS configuration examples in config templates.
+
+### Changed
+- Global SSL settings now apply to JSON connection definitions.
+- SSL "preferred" maps to "skip-verify" for Go MySQL driver compatibility.
+- Updated dependencies, including the MCP SDK.
+
+### Fixed
+- Linter warnings in tests (errorlint, staticcheck).
+- Error comparisons in tests now use errors.Is for wrapped errors.
+- SQL validator empty branch removed.
+
+### Tests
+- Improved unit test coverage for internal MySQL client.
+- Improved HTTP handler coverage for cmd/mysql-mcp-server.
+
+### Documentation
+- Updated README for SSL/TLS behavior and configuration.
+- Corrected config file search paths in architecture docs.
+
+### Dependencies
+- github.com/modelcontextprotocol/go-sdk v1.1.0 -> v1.2.0
+- github.com/dlclark/regexp2 v1.10.0 -> v1.11.5
+- github.com/google/jsonschema-go v0.3.0 -> v0.4.2
+- golang.org/x/oauth2 v0.30.0 -> v0.34.0


### PR DESCRIPTION
## Summary

Adds the v1.5.0 changelog entry covering recent fixes, documentation updates, and dependency upgrades.

Fixes #59

## Highlights

- SSL/TLS behavior updates (global SSL for JSON connections, preferred mapped to skip-verify)
- Linter warning fixes (errorlint, staticcheck)
- Architecture documentation updates
- Test coverage improvements
- Dependency updates (including MCP SDK)
- GitHub issue/PR templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c3e11d6965e52db83fd9b266c2332f0f049f12ed. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->