### PR TITLE
docs: clarify Docker tag format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -138,6 +138,7 @@ release:
     ```bash
     docker pull ghcr.io/askdba/mysql-mcp-server:{{ .Version }}
     ```
+    > Note: Docker tags do not include the leading "v" (use {{ .Version }}, not v{{ .Version }}).
     
     **Build from Source:**
     ```bash

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ brew install askdba/tap/mysql-mcp-server
 docker pull ghcr.io/askdba/mysql-mcp-server:latest
 ```
 
+> Note: Docker image tags use the raw version number without a leading "v"
+> (e.g., `1.5.0`, not `v1.5.0`).
+
 ### Download Binary
 
 Download the latest release from [GitHub Releases](https://github.com/askdba/mysql-mcp-server/releases).


### PR DESCRIPTION
## Summary\n\nClarifies that Docker image tags use the raw version (no leading v) in README and release notes.\n\nFixes #74\n\n## Details\n- README Docker section now includes a short note\n- GoReleaser release header includes a reminder\n\n## Example\n- Correct: ghcr.io/askdba/mysql-mcp-server:1.5.0\n- Incorrect: ghcr.io/askdba/mysql-mcp-server:v1.5.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies Docker tag format to prevent version prefix confusion.
> 
> - Updates README Docker section with a note that image tags use raw versions without a leading `v` (e.g., `1.5.0`, not `v1.5.0`)
> - Adds the same reminder to the GoReleaser release header in `.goreleaser.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510e40da8519ca3d7773160ca5562094ff63b01a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->