### PR TITLE
fix(config): respect rate limit env vars

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -270,10 +270,10 @@ func (fc *FileConfig) ToConfig() *Config {
 		if fc.HTTP.RateLimit.Enabled != nil {
 			cfg.RateLimitEnabled = *fc.HTTP.RateLimit.Enabled
 		}
-		if fc.HTTP.RateLimit.RPS != nil && *fc.HTTP.RateLimit.RPS > 0 {
+		if fc.HTTP.RateLimit.RPS != nil {
 			cfg.RateLimitRPS = *fc.HTTP.RateLimit.RPS
 		}
-		if fc.HTTP.RateLimit.Burst != nil && *fc.HTTP.RateLimit.Burst > 0 {
+		if fc.HTTP.RateLimit.Burst != nil {
 			cfg.RateLimitBurst = *fc.HTTP.RateLimit.Burst
 		}
 	}

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,6 +87,15 @@ http:
 	if cfg.Pool.MaxIdleConns != 10 {
 		t.Errorf("expected max_idle_conns 10, got %d", cfg.Pool.MaxIdleConns)
 	}
+	if cfg.Pool.ConnMaxLifetimeMinutes != 60 {
+		t.Errorf("expected conn_max_lifetime_minutes 60, got %d", cfg.Pool.ConnMaxLifetimeMinutes)
+	}
+	if cfg.Pool.ConnMaxIdleTimeMinutes != 15 {
+		t.Errorf("expected conn_max_idle_time_minutes 15, got %d", cfg.Pool.ConnMaxIdleTimeMinutes)
+	}
+	if cfg.Pool.PingTimeoutSeconds != 10 {
+		t.Errorf("expected ping_timeout_seconds 10, got %d", cfg.Pool.PingTimeoutSeconds)
+	}
 
 	// Verify features
 	if !cfg.Features.ExtendedTools {
@@ -123,7 +133,18 @@ http:
 		t.Error("expected rate_limit.enabled true")
 	}
 	if cfg.HTTP.RateLimit.RPS == nil || *cfg.HTTP.RateLimit.RPS != 50 {
-		t.Errorf("expected rate_limit.rps 50, got %v", cfg.HTTP.RateLimit.RPS)
+		val := "(nil)"
+		if cfg.HTTP.RateLimit.RPS != nil {
+			val = fmt.Sprintf("%f", *cfg.HTTP.RateLimit.RPS)
+		}
+		t.Errorf("expected rate_limit.rps 50, got %s", val)
+	}
+	if cfg.HTTP.RateLimit.Burst == nil || *cfg.HTTP.RateLimit.Burst != 100 {
+		val := "(nil)"
+		if cfg.HTTP.RateLimit.Burst != nil {
+			val = fmt.Sprintf("%d", *cfg.HTTP.RateLimit.Burst)
+		}
+		t.Errorf("expected rate_limit.burst 100, got %s", val)
 	}
 }
 


### PR DESCRIPTION
Fixes #76

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates config handling to avoid unintended overrides and allow finer control of rate limiting.
> 
> - Change `FileHTTPConfig.RateLimit` to a pointer and `FileRateLimitConfig` fields (`enabled`, `rps`, `burst`) to pointers; `rps` now `float64`
> - Apply rate limit settings in `ToConfig()` only if `rate_limit` exists and fields are non-nil
> - Update `PrintConfig()` to emit pointer-based rate limit fields
> - Adjust tests to new shapes and add assertions for pool and rate limit defaults/values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b82bbe80bb1a49f7fbcdb14df8ee466e32f165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limit RPS now accepts decimal values for finer-grained control.
  * Rate limit fields are optional and can be partially specified; omitted fields preserve defaults and no longer unintentionally override settings.
  * Improved handling when rate limiting is not provided, reducing configuration errors.

* **Tests**
  * Updated configuration tests to validate nullable/partial rate-limit and connection pool settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->