### PR TITLE
fix: SSH tunnel review items (expand ~, replace on duplicate name, doc host key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Semantic Versioning.
 
 ## [Unreleased]
 ### Added
-- SSH tunneling (bastion host) support: connect to MySQL via `ssh_host`, `ssh_user`, `ssh_key_path`, and optional `ssh_port` (config file or `MYSQL_SSH_*` env vars).
+- SSH tunneling (bastion host) support: connect to MySQL via `ssh_host`, `ssh_user`, `ssh_key_path`, and optional `ssh_port` (config file or `MYSQL_SSH_*` env vars). `key_path` supports `~` and `~/path` (expanded to user home). Bastion host key verification is not performed.
 - Native support for MariaDB 10.x and 11.x.
 - Automatic server type detection (`mysql` vs `mariadb`) in `server_info` tool.
 - MariaDB 11.4 integration test target in `Makefile` and `docker-compose.test.yml`.

--- a/cmd/mysql-mcp-server/connection.go
+++ b/cmd/mysql-mcp-server/connection.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/askdba/mysql-mcp-server/internal/config"
 	"github.com/askdba/mysql-mcp-server/internal/sshtunnel"
 	"github.com/askdba/mysql-mcp-server/internal/util"
+	"github.com/go-sql-driver/mysql"
 )
 
 // ServerType represents the type of the database server.
@@ -47,9 +47,25 @@ func NewConnectionManager() *ConnectionManager {
 }
 
 // AddConnectionWithPoolConfig adds a new connection with pool configuration.
+// If a connection with the same name already exists, it and its SSH tunnel (if any) are closed and replaced.
 func (cm *ConnectionManager) AddConnectionWithPoolConfig(connCfg config.ConnectionConfig, cfg *config.Config) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
+
+	// If replacing an existing connection, close it and its tunnel first to avoid leaks
+	if existing, ok := cm.connections[connCfg.Name]; ok {
+		existing.Close()
+		delete(cm.connections, connCfg.Name)
+		delete(cm.configs, connCfg.Name)
+		delete(cm.serverTypes, connCfg.Name)
+		if closeTunnel := cm.tunnelClosers[connCfg.Name]; closeTunnel != nil {
+			closeTunnel()
+			delete(cm.tunnelClosers, connCfg.Name)
+		}
+		if cm.activeConn == connCfg.Name {
+			cm.activeConn = ""
+		}
+	}
 
 	dsn := config.ApplySSLToDSN(connCfg.DSN, connCfg.SSL)
 
@@ -119,6 +135,10 @@ func (cm *ConnectionManager) AddConnectionWithPoolConfig(connCfg config.Connecti
 	defer cancel()
 	if err := conn.PingContext(ctx); err != nil {
 		conn.Close()
+		if closer := cm.tunnelClosers[connCfg.Name]; closer != nil {
+			closer()
+			delete(cm.tunnelClosers, connCfg.Name)
+		}
 		return fmt.Errorf("failed to ping connection %s: %w", connCfg.Name, err)
 	}
 

--- a/internal/sshtunnel/tunnel.go
+++ b/internal/sshtunnel/tunnel.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -22,15 +24,35 @@ type Config struct {
 	Port    int    // SSH port (0 = default 22)
 }
 
+// expandTilde returns path with a leading "~" or "~/" expanded to the user's home directory.
+func expandTilde(path string) (string, error) {
+	if path == "" || (path != "~" && !strings.HasPrefix(path, "~/")) {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("expand ~ in key path: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
+}
+
 // Tunnel starts a local listener that forwards connections to remoteAddr via SSH.
 // Returns the local address (e.g. "127.0.0.1:12345") and a close function.
 // remoteAddr should be the MySQL server address (e.g. "db.example.com:3306").
+// KeyPath may start with "~/" or be "~" to mean the current user's home directory.
 func Tunnel(cfg Config, remoteAddr string) (localAddr string, closeFn func(), err error) {
 	if cfg.Host == "" || cfg.User == "" || cfg.KeyPath == "" {
 		return "", nil, fmt.Errorf("ssh tunnel requires host, user, and key_path")
 	}
 
-	key, err := os.ReadFile(cfg.KeyPath)
+	keyPath, err := expandTilde(cfg.KeyPath)
+	if err != nil {
+		return "", nil, err
+	}
+	key, err := os.ReadFile(keyPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("read SSH key: %w", err)
 	}
@@ -49,7 +71,7 @@ func Tunnel(cfg Config, remoteAddr string) (localAddr string, closeFn func(), er
 	sshConfig := &ssh.ClientConfig{
 		User:            cfg.User,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // bastion; consider AcceptHostKey in future
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // Bastion: host key verification not performed; consider known_hosts in future
 		Timeout:         15 * time.Second,
 	}
 

--- a/internal/sshtunnel/tunnel_test.go
+++ b/internal/sshtunnel/tunnel_test.go
@@ -34,3 +34,16 @@ func TestTunnel_InvalidKeyPath(t *testing.T) {
 		t.Error("expected error for nonexistent key file")
 	}
 }
+
+func TestTunnel_ExpandTildeKeyPath(t *testing.T) {
+	// KeyPath "~/nonexistent_key" is expanded to $HOME/nonexistent_key, then ReadFile fails
+	_, _, err := Tunnel(Config{
+		Host:    "bastion.example.com",
+		User:    "deploy",
+		KeyPath: "~/nonexistent_ssh_key_12345",
+		Port:    22,
+	}, "mysql.internal:3306")
+	if err == nil {
+		t.Error("expected error when key path expands to nonexistent file")
+	}
+}


### PR DESCRIPTION
Follow-up to SSH tunnel (bastion) PR:

- **Expand `~` for `key_path`**: `internal/sshtunnel` expands `~` and `~/` to user home before reading the key (README/config `~/.ssh/id_rsa` now works).
- **Replace connection on duplicate name**: When `AddConnectionWithPoolConfig` is called with an existing connection name, the old DB and its SSH tunnel are closed before adding the new one (avoids leak).
- **Document host key**: CHANGELOG and code comment note that bastion host key verification is not performed.

Tests: `TestTunnel_ExpandTildeKeyPath` added; existing unit and integration tests pass.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection lifecycle and SSH tunneling cleanup paths; mistakes could lead to leaked resources or dropped/incorrect connections, but the change is localized and covered by a new test.
> 
> **Overview**
> Improves SSH tunneling by expanding `ssh_key_path` values beginning with `~`/`~/` to the user home directory before reading the private key, with a new unit test covering the behavior.
> 
> Updates `ConnectionManager.AddConnectionWithPoolConfig` to *replace* an existing connection of the same name by closing the prior DB handle and SSH tunnel (and also closing the tunnel on ping failures) to avoid resource leaks, and documents that bastion host key verification is not performed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56e51186c1ba4b564bc912eca7f835dc745e3b7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH key paths now support tilde (~) and tilde-slash (~/) expansion to resolve home directory references
  * Enhanced Unicode support for MariaDB initialization scripts

* **Bug Fixes**
  * Improved SSH tunnel cleanup during connection failures to prevent resource leaks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->