### PR TITLE
feat: Silent mode and daemon mode (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Semantic Versioning.
 
 ## [Unreleased]
 ### Added
+- `--silent` / `-s`: suppress INFO and WARN logs (ERROR still printed to stderr). Useful for production or when running under a process manager.
+- `--daemon` / `-d`: run in background (fork and detach; intended for HTTP mode on Unix). On Windows, use a service manager instead.
+- Example systemd unit in `contrib/systemd/mysql-mcp-server.service` and launchd plist in `contrib/launchd/com.askdba.mysql-mcp-server.plist`.
+- Documentation: [docs/silent-and-daemon.md](docs/silent-and-daemon.md). Examples: [examples/config.yaml](examples/config.yaml) comments and [examples/production-usage.md](examples/production-usage.md).
 - SSH tunneling (bastion host) support: connect to MySQL via `ssh_host`, `ssh_user`, `ssh_key_path`, and optional `ssh_port` (config file or `MYSQL_SSH_*` env vars).
 - Native support for MariaDB 10.x and 11.x.
 - Automatic server type detection (`mysql` vs `mariadb`) in `server_info` tool.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,15 @@ mysql-mcp-server --validate-config /path/to/config.yaml
 
 # Print current configuration as YAML
 mysql-mcp-server --print-config
+
+# Silent mode: suppress INFO/WARN logs (only errors to stderr)
+mysql-mcp-server --silent --config /path/to/config.yaml
+
+# Daemon mode: run HTTP server in background (Unix; use with MYSQL_MCP_HTTP=1)
+MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --config /path/to/config.yaml
 ```
+
+**Silent and daemon mode:** Use `-s` / `--silent` to reduce log noise in production (INFO and WARN are suppressed; ERROR still goes to stderr). Use `-d` / `--daemon` to run the HTTP server detached in the background on Unix. For long-running services, use the example [systemd unit](contrib/systemd/mysql-mcp-server.service) or [launchd plist](contrib/launchd/com.askdba.mysql-mcp-server.plist). See [Silent and daemon mode](docs/silent-and-daemon.md) for details.
 
 **Priority:** Environment variables override config file values, allowing:
 - Base configuration in file
@@ -1064,6 +1072,17 @@ export MYSQL_HTTP_RATE_LIMIT_BURST=200  # Allow bursts up to 200
 ```
 
 When rate limited, clients receive HTTP 429 (Too Many Requests) with a `Retry-After: 1` header.
+
+### Running as a service (daemon)
+
+To run the REST API server in the background or under a process manager:
+
+- **Unix (foreground detach):** `MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --config /path/to/config.yaml` (forks and exits the parent; child runs detached).
+- **systemd:** Copy and customize [contrib/systemd/mysql-mcp-server.service](contrib/systemd/mysql-mcp-server.service), then `systemctl enable --now mysql-mcp-server`.
+- **macOS launchd:** Copy and customize [contrib/launchd/com.askdba.mysql-mcp-server.plist](contrib/launchd/com.askdba.mysql-mcp-server.plist) into `~/Library/LaunchAgents/` or `/Library/LaunchDaemons/`.
+- **Windows:** Use a Windows Service wrapper or run in a terminal; `--daemon` is not supported.
+
+Use `--silent` to suppress INFO/WARN logs when running under a service manager. See [docs/silent-and-daemon.md](docs/silent-and-daemon.md).
 
 ### API Endpoints
 

--- a/cmd/mysql-mcp-server/args_test.go
+++ b/cmd/mysql-mcp-server/args_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"os"
 	"testing"
 )
 
@@ -11,6 +13,8 @@ func TestParseArgs(t *testing.T) {
 		wantAction     string
 		wantConfigPath string
 		wantValidPath  string
+		wantSilent     bool
+		wantDaemon     bool
 		wantErr        bool
 		errContains    string
 	}{
@@ -88,6 +92,34 @@ func TestParseArgs(t *testing.T) {
 			args:        []string{"--validate-config"},
 			wantErr:     true,
 			errContains: "--validate-config requires a path argument",
+		},
+
+		// Silent and daemon flags
+		{
+			name:       "silent flag",
+			args:       []string{"--silent"},
+			wantSilent: true,
+		},
+		{
+			name:       "silent short flag",
+			args:       []string{"-s"},
+			wantSilent: true,
+		},
+		{
+			name:       "daemon flag",
+			args:       []string{"--daemon"},
+			wantDaemon: true,
+		},
+		{
+			name:       "daemon short flag",
+			args:       []string{"-d"},
+			wantDaemon: true,
+		},
+		{
+			name:           "silent and config",
+			args:           []string{"--silent", "--config", "/etc/config.yaml"},
+			wantConfigPath: "/etc/config.yaml",
+			wantSilent:     true,
 		},
 
 		// Combined flags - the key fix for this PR
@@ -185,7 +217,33 @@ func TestParseArgs(t *testing.T) {
 			if result.validatePath != tt.wantValidPath {
 				t.Errorf("parseArgs() validatePath = %q, want %q", result.validatePath, tt.wantValidPath)
 			}
+			if result.silent != tt.wantSilent {
+				t.Errorf("parseArgs() silent = %v, want %v", result.silent, tt.wantSilent)
+			}
+			if result.daemon != tt.wantDaemon {
+				t.Errorf("parseArgs() daemon = %v, want %v", result.daemon, tt.wantDaemon)
+			}
 		})
+	}
+}
+
+// TestPrintHelpContainsSilentAndDaemon ensures the help text documents --silent and --daemon.
+func TestPrintHelpContainsSilentAndDaemon(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	printHelp()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	help := buf.String()
+	if !contains(help, "--silent") || !contains(help, "--daemon") {
+		excerpt := help
+		if len(excerpt) > 200 {
+			excerpt = excerpt[:200]
+		}
+		t.Errorf("help text should contain --silent and --daemon; got (excerpt): %s", excerpt)
 	}
 }
 

--- a/cmd/mysql-mcp-server/daemon_unix.go
+++ b/cmd/mysql-mcp-server/daemon_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// maybeDaemonize forks the process and exits the parent when --daemon is set.
+// The child process is started in a new session (detached from terminal).
+// Only makes sense when running in HTTP mode; caller should avoid passing --daemon for stdio MCP.
+func maybeDaemonize(parsed parsedArgs) {
+	if !parsed.daemon {
+		return
+	}
+	// Build child args: same as current but without --daemon and -d
+	args := make([]string, 0, len(os.Args)-1)
+	for _, a := range os.Args[1:] {
+		if a == "--daemon" || a == "-d" {
+			continue
+		}
+		args = append(args, a)
+	}
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "daemon: failed to start child: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/mysql-mcp-server/daemon_windows.go
+++ b/cmd/mysql-mcp-server/daemon_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+// maybeDaemonize is a no-op on Windows (no fork/setsid). Use a service manager or
+// start the process in the background instead.
+func maybeDaemonize(parsed parsedArgs) {}

--- a/cmd/mysql-mcp-server/http.go
+++ b/cmd/mysql-mcp-server/http.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -550,9 +551,10 @@ func startHTTPServer(port int, vectorMode bool) {
 			"version":      Version,
 		})
 
-		log.Printf("REST API endpoints available at http://localhost:%d/api", port)
-		log.Printf("Health check at http://localhost:%d/health", port)
-		log.Printf("Press Ctrl+C to stop the server")
+		logInfo("REST API endpoints", map[string]interface{}{
+			"api":    "http://localhost:" + strconv.Itoa(port) + "/api",
+			"health": "http://localhost:" + strconv.Itoa(port) + "/health",
+		})
 
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("HTTP server error: %v", err)
@@ -569,7 +571,7 @@ func startHTTPServer(port int, vectorMode bool) {
 
 	// Attempt graceful shutdown
 	if err := server.Shutdown(ctx); err != nil {
-		log.Printf("Server shutdown error: %v", err)
+		logError("Server shutdown error", map[string]interface{}{"error": err.Error()})
 	} else {
 		logInfo("Server stopped gracefully", nil)
 	}

--- a/cmd/mysql-mcp-server/logging.go
+++ b/cmd/mysql-mcp-server/logging.go
@@ -22,6 +22,9 @@ type LogEntry struct {
 }
 
 func logJSON(level, message string, fields map[string]interface{}) {
+	if silentMode && (level == "INFO" || level == "WARN") {
+		return
+	}
 	entry := LogEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 		Level:     level,

--- a/cmd/mysql-mcp-server/logging_test.go
+++ b/cmd/mysql-mcp-server/logging_test.go
@@ -12,6 +12,38 @@ import (
 	"time"
 )
 
+func TestLogInfoSilentMode(t *testing.T) {
+	// When silentMode is true, logInfo and logWarn must not produce output; logError must still output.
+	oldSilent := silentMode
+	defer func() { silentMode = oldSilent }()
+
+	oldStderr := os.Stderr
+	oldLogOutput := log.Writer()
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	log.SetOutput(w)
+
+	silentMode = true
+	logInfo("should not appear", map[string]interface{}{"key": "value"})
+	logWarn("also should not appear", nil)
+	logError("this must appear", map[string]interface{}{"error": "test"})
+
+	w.Close()
+	os.Stderr = oldStderr
+	log.SetOutput(oldLogOutput)
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if strings.Contains(output, "should not appear") || strings.Contains(output, "also should not appear") {
+		t.Error("silent mode: INFO/WARN should be suppressed")
+	}
+	if !strings.Contains(output, "this must appear") && !strings.Contains(output, "ERROR") {
+		t.Error("silent mode: ERROR should still be printed")
+	}
+}
+
 func TestNewQueryTimer(t *testing.T) {
 	timer := NewQueryTimer("test_tool")
 	if timer == nil {

--- a/cmd/mysql-mcp-server/main.go
+++ b/cmd/mysql-mcp-server/main.go
@@ -39,6 +39,9 @@ var (
 	tokenTracking  bool
 	tokenModel     string
 	tokenEstimator TokenEstimator
+
+	// silentMode suppresses INFO and WARN logs (--silent); ERROR still goes to stderr.
+	silentMode bool
 )
 
 // ===== Argument Parsing =====
@@ -48,6 +51,8 @@ type parsedArgs struct {
 	action       string // "", "version", "help", "print-config", "validate-config"
 	configPath   string // path from --config or --config=
 	validatePath string // path for --validate-config
+	silent       bool   // --silent or -s: suppress INFO/WARN logs
+	daemon       bool   // --daemon: fork to background (HTTP mode)
 	err          error  // parsing error (e.g., unknown flag)
 }
 
@@ -84,6 +89,10 @@ func parseArgs(args []string) parsedArgs {
 			result.action = "validate-config"
 			result.validatePath = args[0]
 			args = args[1:]
+		case "--silent", "-s":
+			result.silent = true
+		case "--daemon", "-d":
+			result.daemon = true
 		default:
 			// Check if it's --config=path format
 			if len(arg) > 9 && arg[:9] == "--config=" {
@@ -115,6 +124,8 @@ func main() {
 	if parsed.configPath != "" {
 		config.ConfigFilePath = parsed.configPath
 	}
+	silentMode = parsed.silent
+	maybeDaemonize(parsed)
 
 	// Handle immediate actions
 	switch parsed.action {
@@ -180,7 +191,7 @@ func main() {
 	// Add all connections from config
 	for _, connCfg := range cfg.Connections {
 		if err := connManager.AddConnectionWithPoolConfig(connCfg, cfg); err != nil {
-			log.Printf("Warning: failed to add connection '%s': %v", connCfg.Name, err)
+			logWarn("failed to add connection", map[string]interface{}{"name": connCfg.Name, "error": err.Error()})
 		} else {
 			logInfo("connection added", map[string]interface{}{
 				"name": connCfg.Name,
@@ -313,7 +324,7 @@ func registerVectorTools(server *mcp.Server) {
 }
 
 func registerExtendedTools(server *mcp.Server) {
-	log.Printf("Registering extended MySQL tools...")
+	logInfo("Registering extended MySQL tools...", nil)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_indexes",
@@ -412,6 +423,8 @@ OPTIONS:
     -h, --help                  Show this help message
     -v, --version               Show version information
     -c, --config PATH           Use config file at PATH
+    -s, --silent                Suppress INFO and WARN logs (ERROR still printed)
+    -d, --daemon                Run in background (fork and detach; use with MYSQL_MCP_HTTP=1)
     --print-config              Print current configuration as YAML
     --validate-config PATH      Validate config file at PATH
 
@@ -488,6 +501,12 @@ EXAMPLES:
     export MYSQL_MCP_HTTP=1
     export MYSQL_HTTP_PORT=9306
     mysql-mcp-server
+
+    # Silent mode (production; only errors to stderr)
+    mysql-mcp-server --silent --config /etc/mysql-mcp-server/config.yaml
+
+    # Run HTTP server as daemon (Unix)
+    MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --config /path/to/config.yaml
 
 FEATURES:
     - Fully read-only (blocks all non-SELECT/SHOW/DESCRIBE/EXPLAIN)

--- a/contrib/launchd/com.askdba.mysql-mcp-server.plist
+++ b/contrib/launchd/com.askdba.mysql-mcp-server.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.askdba.mysql-mcp-server</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/mysql-mcp-server</string>
+		<string>--config</string>
+		<string>/usr/local/etc/mysql-mcp-server/config.yaml</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>MYSQL_MCP_HTTP</key>
+		<string>1</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/usr/local/var/log/mysql-mcp-server.log</string>
+	<key>StandardErrorPath</key>
+	<string>/usr/local/var/log/mysql-mcp-server.err</string>
+</dict>
+</plist>

--- a/contrib/systemd/mysql-mcp-server.service
+++ b/contrib/systemd/mysql-mcp-server.service
@@ -1,0 +1,29 @@
+# systemd unit for mysql-mcp-server (HTTP mode)
+# Copy to /etc/systemd/system/ and adjust paths and environment.
+#
+#   sudo cp contrib/systemd/mysql-mcp-server.service /etc/systemd/system/
+#   sudo edit /etc/systemd/system/mysql-mcp-server.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now mysql-mcp-server
+#
+# Use a config file or EnvironmentFile for MYSQL_DSN and other vars.
+
+[Unit]
+Description=MySQL MCP Server (HTTP REST API)
+Documentation=https://github.com/askdba/mysql-mcp-server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/mysql-mcp-server --config /etc/mysql-mcp-server/config.yaml
+# Optional: pass MYSQL_* via environment file
+# EnvironmentFile=/etc/mysql-mcp-server/env
+Restart=on-failure
+RestartSec=5s
+# Run as dedicated user (create with useradd mysql-mcp)
+# User=mysql-mcp
+# Group=mysql-mcp
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -447,6 +447,8 @@ graph TB
     ConfigFile --> Docker
 ```
 
+For running the server as a background service (e.g. under systemd or launchd) with minimal logging, see [Silent and daemon mode](silent-and-daemon.md).
+
 ---
 
 ## Data Flow Summary
@@ -478,4 +480,10 @@ flowchart LR
     Execute --> Format
     Format --> Response
 ```
+
+---
+
+## See also
+
+- [Silent and daemon mode](silent-and-daemon.md) — `--silent`, `--daemon`, and service manager templates (systemd, launchd).
 

--- a/docs/silent-and-daemon.md
+++ b/docs/silent-and-daemon.md
@@ -1,0 +1,87 @@
+# Silent and daemon mode
+
+This document describes how to run mysql-mcp-server with minimal console output (silent mode) and as a background process (daemon mode), suitable for production and service managers.
+
+## Silent mode (`-s` / `--silent`)
+
+When `--silent` (or `-s`) is set:
+
+- **INFO** and **WARN** log messages are suppressed.
+- **ERROR** messages are still written to stderr so failures and diagnostics remain visible.
+
+Use silent mode when:
+
+- Running under systemd, launchd, or another process manager that logs separately.
+- Reducing noise in container or CI logs.
+- The server is already monitored via health checks or audit logs.
+
+**Examples:**
+
+```bash
+mysql-mcp-server --silent --config /etc/mysql-mcp-server/config.yaml
+MYSQL_MCP_HTTP=1 mysql-mcp-server --silent --config /path/to/config.yaml
+```
+
+Structured (JSON) logging is unaffected by `--silent` for the **level** of messages: if `MYSQL_MCP_JSON_LOGS=1`, only INFO/WARN lines are skipped; ERROR lines are still emitted as JSON.
+
+## Daemon mode (`-d` / `--daemon`)
+
+When `--daemon` (or `-d`) is set on **Unix**:
+
+- The process **forks** a child that runs the server.
+- The **parent** exits immediately (exit code 0).
+- The **child** runs in a new session (detached from the terminal) and continues with the same configuration.
+
+Daemon mode is intended for **HTTP REST API mode** (`MYSQL_MCP_HTTP=1`). Using it with stdio MCP is possible but less common (the child would read from stdin and write to stdout with no terminal).
+
+**Examples:**
+
+```bash
+# Start HTTP server in background
+MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --config /path/to/config.yaml
+
+# With silent mode (recommended when running as daemon)
+MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --silent --config /path/to/config.yaml
+```
+
+**Windows:** `--daemon` is a no-op. Use a Windows Service or run the process in the background (e.g. in a separate terminal or via a scheduler).
+
+## Service manager templates
+
+The repository includes example unit files for running the server under a process manager:
+
+| Platform   | File                                                                 | Description                    |
+|-----------|----------------------------------------------------------------------|--------------------------------|
+| systemd   | [contrib/systemd/mysql-mcp-server.service](contrib/systemd/mysql-mcp-server.service) | Example systemd unit           |
+| launchd   | [contrib/launchd/com.askdba.mysql-mcp-server.plist](contrib/launchd/com.askdba.mysql-mcp-server.plist) | Example launchd plist (macOS)  |
+
+### systemd (Linux)
+
+1. Copy the unit file:  
+   `sudo cp contrib/systemd/mysql-mcp-server.service /etc/systemd/system/`
+2. Edit paths and environment:  
+   `sudo edit /etc/systemd/system/mysql-mcp-server.service`  
+   Set `ExecStart` to your binary and config path. Optionally use `EnvironmentFile=` for `MYSQL_*` variables.
+3. Reload and enable:  
+   `sudo systemctl daemon-reload`  
+   `sudo systemctl enable --now mysql-mcp-server`
+
+### launchd (macOS)
+
+1. Copy the plist:  
+   `cp contrib/launchd/com.askdba.mysql-mcp-server.plist ~/Library/LaunchAgents/`  
+   (or `/Library/LaunchDaemons/` for a system-wide service)
+2. Edit `ProgramArguments` and paths (binary, config, log paths).
+3. Load and start:  
+   `launchctl load ~/Library/LaunchAgents/com.askdba.mysql-mcp-server.plist`
+
+## Summary
+
+| Flag / option   | Effect |
+|-----------------|--------|
+| `-s` / `--silent` | Suppress INFO and WARN; ERROR still to stderr |
+| `-d` / `--daemon` | Fork and detach (Unix); parent exits, child runs server |
+| contrib/systemd  | Example systemd unit for Linux |
+| contrib/launchd  | Example launchd plist for macOS |
+
+For full CLI options, run `mysql-mcp-server --help`.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -6,6 +6,10 @@
 #
 # Or specify with: mysql-mcp-server --config /path/to/config.yaml
 #
+# Command-line flags (optional):
+#   --silent, -s   Suppress INFO/WARN logs (only errors to stderr); good for production.
+#   --daemon, -d   Run in background (Unix, typically with http.enabled: true).
+#
 # Environment variables override config file values.
 
 # Database connections

--- a/examples/production-usage.md
+++ b/examples/production-usage.md
@@ -1,0 +1,57 @@
+# Production usage examples
+
+Example invocations for running mysql-mcp-server in production or under a process manager.
+
+## Silent mode (minimal logs)
+
+Only errors are written to stderr; INFO and WARN are suppressed.
+
+```bash
+mysql-mcp-server --silent --config /etc/mysql-mcp-server/config.yaml
+```
+
+With environment-only config:
+
+```bash
+export MYSQL_DSN="user:pass@tcp(host:3306)/db?parseTime=true"
+mysql-mcp-server --silent
+```
+
+## HTTP server as daemon (Unix)
+
+Fork and run the REST API server in the background. The parent process exits; the child runs detached.
+
+```bash
+export MYSQL_DSN="user:pass@tcp(host:3306)/db?parseTime=true"
+export MYSQL_MCP_HTTP=1
+export MYSQL_HTTP_PORT=9306
+mysql-mcp-server --daemon --config /path/to/config.yaml
+```
+
+With silent mode (recommended when running as daemon):
+
+```bash
+MYSQL_MCP_HTTP=1 mysql-mcp-server --daemon --silent --config /path/to/config.yaml
+```
+
+## systemd (Linux)
+
+See [contrib/systemd/mysql-mcp-server.service](../contrib/systemd/mysql-mcp-server.service). After copying and editing:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now mysql-mcp-server
+```
+
+## launchd (macOS)
+
+See [contrib/launchd/com.askdba.mysql-mcp-server.plist](../contrib/launchd/com.askdba.mysql-mcp-server.plist). After copying and editing:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.askdba.mysql-mcp-server.plist
+```
+
+## More details
+
+- [Silent and daemon mode](../docs/silent-and-daemon.md) in the docs folder.
+- [README configuration section](../README.md#configuration) for config file and env vars.

--- a/tests/integration/silent_daemon_test.go
+++ b/tests/integration/silent_daemon_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildServerBinary builds cmd/mysql-mcp-server into dir and returns the executable path.
+func buildServerBinary(t *testing.T, dir string) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// Find module root (directory containing go.mod)
+	moduleRoot := wd
+	for {
+		if _, err := os.Stat(filepath.Join(moduleRoot, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(moduleRoot)
+		if parent == moduleRoot {
+			t.Fatal("could not find go.mod to determine module root")
+		}
+		moduleRoot = parent
+	}
+	exe := filepath.Join(dir, "mysql-mcp-server")
+	if goexe := os.Getenv("GOEXE"); goexe != "" {
+		exe += goexe
+	}
+	cmd := exec.Command("go", "build", "-o", exe, "./cmd/mysql-mcp-server")
+	cmd.Dir = moduleRoot
+	if err := cmd.Run(); err != nil {
+		t.Skipf("could not build mysql-mcp-server: %v (skip if go not in PATH)", err)
+	}
+	return exe
+}
+
+// TestSilentVersion runs the server binary with --silent --version and verifies
+// it exits 0 and prints version info (no INFO/WARN lines when --silent).
+func TestSilentVersion(t *testing.T) {
+	exe := buildServerBinary(t, t.TempDir())
+
+	run := exec.Command(exe, "--silent", "--version")
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--silent --version failed: %v\noutput: %s", err, out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "mysql-mcp-server") {
+		t.Errorf("expected version output to contain 'mysql-mcp-server'; got: %s", output)
+	}
+	// With --silent, we should not see [INFO] or [WARN] in version output (version is printf to stdout)
+	if strings.Contains(output, "[INFO]") || strings.Contains(output, "[WARN]") {
+		t.Errorf("--silent should not produce INFO/WARN; got: %s", output)
+	}
+}
+
+// TestHelpContainsSilentAndDaemon ensures the CLI help documents --silent and --daemon.
+func TestHelpContainsSilentAndDaemon(t *testing.T) {
+	exe := buildServerBinary(t, t.TempDir())
+
+	run := exec.Command(exe, "--help")
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("--help failed: %v\noutput: %s", err, out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "--silent") || !strings.Contains(output, "--daemon") {
+		t.Errorf("help should document --silent and --daemon; got (excerpt): %s", output[:min(400, len(output))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
Add `--silent` / `-s` and `--daemon` / `-d` flags plus service templates for production and process managers.

## Related Issue
Fixes #78

## Type of Change
- [x] New feature (non-breaking)

## Changes Made
- **Silent mode (`-s` / `--silent`):** Suppress INFO and WARN logs; ERROR still goes to stderr.
- **Daemon mode (`-d` / `--daemon`):** Fork and detach on Unix (for HTTP mode); no-op on Windows.
- **contrib:** `contrib/systemd/mysql-mcp-server.service`, `contrib/launchd/com.askdba.mysql-mcp-server.plist`.
- **Docs:** `docs/silent-and-daemon.md`, README section, architecture.md links.
- **Examples:** `examples/config.yaml` comments, `examples/production-usage.md`.
- **Tests:** Unit (parseArgs, silent logging, help text); integration (TestSilentVersion, TestHelpContainsSilentAndDaemon).

## Testing
- [x] `go test ./...` passes
- [x] `go test -tags=integration -run 'TestSilentVersion|TestHelpContainsSilent' ./tests/integration/...` passes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new process forking/detach behavior and changes logging output paths, which can affect production deployments and observability if misconfigured.
> 
> **Overview**
> Adds production-oriented CLI flags: `--silent`/`-s` to suppress INFO/WARN structured logs (while still emitting ERROR), and `--daemon`/`-d` to fork/detach on Unix (no-op on Windows) for running the HTTP server in the background.
> 
> Updates startup/logging paths to use structured `logInfo`/`logWarn`/`logError` consistently (including HTTP endpoint announcements and shutdown errors), and adds docs/examples plus `systemd`/`launchd` service templates. Expands unit + integration tests to cover arg parsing, help text, and silent logging behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e55864624c45393fb611f8658bce3c418614aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--silent` / `-s` flag to suppress INFO and WARN logs while keeping ERROR messages
  * Added `--daemon` / `-d` flag to run the server in the background (Unix platforms)

* **Documentation**
  * Added comprehensive guides for silent and daemon modes
  * Added systemd and launchd service configuration templates
  * Updated README with production usage examples and platform-specific service setup instructions

* **Tests**
  * Added test coverage for silent mode, daemon flags, and help documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->