### PR TITLE
fix(ci): workflow hardening — pre-release gate, format enforcement, summary policy

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -33,16 +33,20 @@ jobs:
 
       - name: Check formatting
         run: |
-          echo "Skipping format check - code is verified formatted locally"
-          go fmt ./... || true
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
 
       - name: Run go vet
         run: go vet ./...
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64.8
           args: --timeout=5m
         continue-on-error: true  # Don't block pipeline on lint issues
 
@@ -292,7 +296,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
@@ -364,7 +368,15 @@ jobs:
           MYSQL_MCP_EXTENDED: "1"
         run: |
           ./mysql-mcp-server &
-          sleep 3
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:9306/health > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              break
+            fi
+            echo "Waiting for server... (${i}/20)"
+            sleep 1
+          done
+          curl -sf http://localhost:9306/health > /dev/null || { echo "Server did not start"; exit 1; }
 
       - name: Test API endpoints
         run: |
@@ -406,9 +418,11 @@ jobs:
           echo "Docker: ${{ needs.docker.result }}"
           echo "API Tests: ${{ needs.api-tests.result }}"
           
-          # Only fail on unit tests and build - lint/security are informational
+          # Fail on unit tests, build, and integration tests; lint/security are informational
           if [ "${{ needs.unit-tests.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ]; then
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.integration-tests.result }}" != "success" ] || \
+             [ "${{ needs.integration-tests-mariadb.result }}" != "success" ]; then
             echo "❌ Critical jobs failed"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,10 @@ jobs:
             echo "Waiting for MySQL... (${i}/30)"
             sleep 2
           done
+          if ! mysqladmin ping -h 127.0.0.1 -u root -ptestpass --silent 2>/dev/null; then
+            echo "MySQL did not become ready after 30 attempts"
+            exit 1
+          fi
 
       - name: Initialize test database
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,68 @@ permissions:
   packages: write
 
 jobs:
+  pre-release-check:
+    name: Pre-release QA Gate
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: testpass
+          MYSQL_DATABASE: testdb
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -u root -ptestpass"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Unit tests
+        run: go test -race -covermode=atomic ./...
+
+      - name: Wait for MySQL
+        run: |
+          for i in $(seq 1 30); do
+            if mysqladmin ping -h 127.0.0.1 -u root -ptestpass --silent 2>/dev/null; then
+              echo "MySQL ready"
+              break
+            fi
+            echo "Waiting for MySQL... (${i}/30)"
+            sleep 2
+          done
+
+      - name: Initialize test database
+        run: |
+          mysql -h 127.0.0.1 -u root -ptestpass < tests/sql/init.sql
+          mysql -h 127.0.0.1 -u root -ptestpass < tests/sql/mcp_test_user.sql
+
+      - name: Integration tests
+        env:
+          MYSQL_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+          MYSQL_TEST_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+        run: go test -v -tags=integration ./...
+
   goreleaser:
     runs-on: ubuntu-latest
+    needs: pre-release-check
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+## [1.7.0-rc.4] - 2026-04-11
+
+Fourth release candidate: optional runtime DSN registration (`add_connection`), SSH bastion host key verification by default, and extended tooling improvements.
+
 ### Security
 
 - **SSH bastion host keys**: the tunnel now verifies the server host key by default using OpenSSH-style **`known_hosts`** (default file `~/.ssh/known_hosts`, or **`MYSQL_SSH_KNOWN_HOSTS`** / config **`known_hosts`**) or a pinned fingerprint (**`MYSQL_SSH_HOST_KEY_FINGERPRINT`** / **`host_key_fingerprint`**). To disable verification (MITM risk), you must **opt in** with **`MYSQL_SSH_STRICT_HOST_KEY_CHECKING=false`** or **`ssh_strict_host_key_checking: false`**. See README.
 
 ### Added
+
+- **`add_connection`** (optional): register a new named MySQL connection at runtime via MCP when **`MYSQL_MCP_EXTENDED=1`** and **`MYSQL_MCP_ENABLE_ADD_CONNECTION=1`**; rejects duplicate names, invalid DSNs, and the **`root`** MySQL user ([#106](https://github.com/askdba/mysql-mcp-server/issues/106)).
 - **`search_schema`**: Find tables and columns matching a pattern across all accessible databases.
 - **`schema_diff`**: Compare table and column structures between two databases.
 - **Column Masking**: Redact sensitive data in `run_query` results using **`MYSQL_MCP_MASK_COLUMNS`** (e.g., `email,password,token`).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
   <img src="./MysqlMCPServerBanner.png" alt="MySQL MCP Server Banner" width="800"/>
   
-  [![Version](https://img.shields.io/badge/version-1.7.0-rc.3-blue.svg)](https://github.com/askdba/mysql-mcp-server/releases)
+  [![Version](https://img.shields.io/badge/version-1.7.0-rc.4-blue.svg)](https://github.com/askdba/mysql-mcp-server/releases)
   [![Go](https://img.shields.io/badge/go-1.24+-00ADD8.svg)](https://golang.org/)
   [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 </div>
@@ -355,7 +355,7 @@ mysql-mcp-server --version
 
 Output:
 ```
-mysql-mcp-server v1.7.0-rc.3
+mysql-mcp-server v1.7.0-rc.4
   Build time: 2025-12-21T11:43:11Z
   Git commit: a1b2c3d
 ```

--- a/README.md
+++ b/README.md
@@ -356,8 +356,8 @@ mysql-mcp-server --version
 Output:
 ```
 mysql-mcp-server v1.7.0-rc.4
-  Build time: 2025-12-21T11:43:11Z
-  Git commit: a1b2c3d
+  Build time: <build time>
+  Git commit: <git sha>
 ```
 
 ## Claude Desktop Integration

--- a/docs/superpowers/plans/2026-04-19-issue-128-workflow-hardening.md
+++ b/docs/superpowers/plans/2026-04-19-issue-128-workflow-hardening.md
@@ -1,0 +1,428 @@
+# CI/Release Workflow Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix seven CI/release workflow gaps identified in issue #128 — pre-release QA gate, format enforcement, integration-test blocking, health-poll, lint pinning, action version alignment, and stale docs.
+
+**Architecture:** All changes are in `.github/workflows/` YAML files and `workflow.md`. No Go code changes. Each task is independently testable via `gh workflow view` or direct inspection.
+
+**Tech Stack:** GitHub Actions, GoReleaser, golangci-lint, gofmt, bash
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `.github/workflows/release.yml` | Add `pre-release-check` job; gate `goreleaser` on it; align `build-push-action` to `@v6` |
+| `.github/workflows/qa.yml` | Fix format check; expand `qa-summary` failure policy; replace `sleep 3`; pin lint version; align `build-push-action` to `@v6` |
+| `workflow.md` | Remove stale issue #104 from backlog |
+
+---
+
+### Task 1: Fix no-op format check in qa.yml
+
+**Files:**
+- Modify: `.github/workflows/qa.yml:34-38`
+
+Current code (no-op):
+```yaml
+- name: Check formatting
+  run: |
+    echo "Skipping format check - code is verified formatted locally"
+    go fmt ./... || true
+```
+
+- [ ] **Step 1: Replace with real gofmt enforcement**
+
+Edit `.github/workflows/qa.yml`, replace the `Check formatting` step:
+```yaml
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+```
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/qa.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Verify locally that current code passes**
+
+```bash
+unformatted=$(gofmt -l .) && [ -z "$unformatted" ] && echo "All files formatted" || echo "Unformatted: $unformatted"
+```
+Expected: `All files formatted`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/qa.yml
+git commit -m "fix(ci): enforce gofmt -l format check instead of no-op go fmt"
+```
+
+---
+
+### Task 2: Pin golangci-lint to a specific version
+
+**Files:**
+- Modify: `.github/workflows/qa.yml` — `golangci-lint-action` step
+
+- [ ] **Step 1: Update lint action version**
+
+In `.github/workflows/qa.yml`, find:
+```yaml
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          args: --timeout=5m
+        continue-on-error: true  # Don't block pipeline on lint issues
+```
+
+Replace with:
+```yaml
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          args: --timeout=5m
+        continue-on-error: true  # Don't block pipeline on lint issues
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/qa.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/qa.yml
+git commit -m "fix(ci): pin golangci-lint to v1.64.8 to prevent surprise breakage"
+```
+
+---
+
+### Task 3: Replace sleep 3 with health-poll in api-tests
+
+**Files:**
+- Modify: `.github/workflows/qa.yml` — `Start REST API server` step
+
+- [ ] **Step 1: Replace sleep with poll loop**
+
+In `.github/workflows/qa.yml`, find:
+```yaml
+      - name: Start REST API server
+        env:
+          MYSQL_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+          MYSQL_MCP_HTTP: "1"
+          MYSQL_MCP_EXTENDED: "1"
+        run: |
+          ./mysql-mcp-server &
+          sleep 3
+```
+
+Replace with:
+```yaml
+      - name: Start REST API server
+        env:
+          MYSQL_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+          MYSQL_MCP_HTTP: "1"
+          MYSQL_MCP_EXTENDED: "1"
+        run: |
+          ./mysql-mcp-server &
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:9306/health > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              break
+            fi
+            echo "Waiting for server... (${i}/20)"
+            sleep 1
+          done
+          curl -sf http://localhost:9306/health > /dev/null || { echo "Server did not start"; exit 1; }
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/qa.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/qa.yml
+git commit -m "fix(ci): replace sleep 3 with health-poll loop in api-tests"
+```
+
+---
+
+### Task 4: Expand qa-summary failure policy to include integration tests
+
+**Files:**
+- Modify: `.github/workflows/qa.yml:410-413`
+
+- [ ] **Step 1: Expand the failure condition**
+
+In `.github/workflows/qa.yml`, find:
+```yaml
+          # Only fail on unit tests and build - lint/security are informational
+          if [ "${{ needs.unit-tests.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ]; then
+            echo "❌ Critical jobs failed"
+            exit 1
+          fi
+```
+
+Replace with:
+```yaml
+          # Fail on unit tests, build, and integration tests; lint/security are informational
+          if [ "${{ needs.unit-tests.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.integration-tests.result }}" != "success" ] || \
+             [ "${{ needs.integration-tests-mariadb.result }}" != "success" ]; then
+            echo "❌ Critical jobs failed"
+            exit 1
+          fi
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/qa.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/qa.yml
+git commit -m "fix(ci): include integration tests in qa-summary failure condition"
+```
+
+---
+
+### Task 5: Align docker/build-push-action to @v6 in qa.yml
+
+**Files:**
+- Modify: `.github/workflows/qa.yml` — Docker Build job
+
+- [ ] **Step 1: Update the action version**
+
+In `.github/workflows/qa.yml`, find:
+```yaml
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+```
+
+Replace with:
+```yaml
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/qa.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/qa.yml
+git commit -m "fix(ci): align docker/build-push-action to @v6 in qa.yml"
+```
+
+---
+
+### Task 6: Add pre-release-check job to release.yml
+
+This is the highest-severity fix: gate `goreleaser` and `docker` on passing unit + integration tests.
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add pre-release-check job**
+
+In `.github/workflows/release.yml`, insert a new job BEFORE the `goreleaser` job. Add after line 11 (`jobs:`):
+
+```yaml
+  pre-release-check:
+    name: Pre-release QA Gate
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: testpass
+          MYSQL_DATABASE: testdb
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -u root -ptestpass"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Unit tests
+        run: go test -race -covermode=atomic ./...
+
+      - name: Wait for MySQL
+        run: |
+          for i in $(seq 1 30); do
+            if mysqladmin ping -h 127.0.0.1 -u root -ptestpass --silent 2>/dev/null; then
+              echo "MySQL ready"
+              break
+            fi
+            echo "Waiting for MySQL... (${i}/30)"
+            sleep 2
+          done
+
+      - name: Initialize test database
+        run: |
+          mysql -h 127.0.0.1 -u root -ptestpass < tests/sql/init.sql
+          mysql -h 127.0.0.1 -u root -ptestpass < tests/sql/mcp_test_user.sql
+
+      - name: Integration tests
+        env:
+          MYSQL_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+          MYSQL_TEST_DSN: "mcpuser:mcppass00@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+        run: go test -v -tags=integration ./...
+
+```
+
+- [ ] **Step 2: Gate goreleaser on pre-release-check**
+
+In `.github/workflows/release.yml`, find:
+```yaml
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+```
+
+Replace with:
+```yaml
+  goreleaser:
+    runs-on: ubuntu-latest
+    needs: pre-release-check
+    steps:
+```
+
+- [ ] **Step 3: Validate YAML**
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/release.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "fix(ci): add pre-release-check job; gate goreleaser on unit + integration tests"
+```
+
+---
+
+### Task 7: Remove stale issue #104 from workflow.md backlog
+
+**Files:**
+- Modify: `workflow.md`
+
+- [ ] **Step 1: Update the backlog table**
+
+In `workflow.md`, find the backlog table row:
+```markdown
+| 104 | Enhancement: richer EXPLAIN as structured output (document existing explain_query) |
+```
+
+Remove it entirely. The row for issue #104 is gone; PR #126 merged it.
+
+Also update the "Recently delivered" line to include #104:
+
+Find:
+```markdown
+**Recently delivered (closed):** #106 (`add_connection`, merged PR **#127**); earlier: #102 (metrics HTTP sidecar),
+```
+
+Replace with:
+```markdown
+**Recently delivered (closed):** #106 (`add_connection`, merged PR **#127**); #104 (richer EXPLAIN, merged PR **#126**); earlier: #102 (metrics HTTP sidecar),
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add workflow.md
+git commit -m "docs: remove stale issue #104 from workflow.md backlog (merged in PR #126)"
+```
+
+---
+
+### Task 8: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/issue-128-workflow-hardening
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "fix(ci): workflow hardening — pre-release gate, format enforcement, summary policy, lint pinning" \
+  --body "$(cat docs/superpowers/plans/2026-04-19-issue-128-workflow-hardening.md | head -10)" \
+  --base main
+```
+
+Use this PR body:
+```
+## Summary
+
+- Add `pre-release-check` job to `release.yml` that runs unit + integration tests before GoReleaser fires
+- Gate `goreleaser` job on `pre-release-check` success
+- Fix no-op format check: replace `go fmt ./... || true` with real `gofmt -l` enforcement
+- Expand `qa-summary` failure policy to block on integration test failures (MySQL + MariaDB)
+- Replace fragile `sleep 3` with health-poll loop in `api-tests`
+- Pin `golangci-lint` to `v1.64.8`
+- Align `docker/build-push-action` to `@v6` in `qa.yml`
+- Remove stale issue #104 from `workflow.md` backlog
+
+Closes #128
+
+## Test plan
+- [ ] All YAML files parse without error
+- [ ] `gofmt -l .` returns empty (no unformatted files)
+- [ ] GitHub Actions run green on this PR
+```

--- a/workflow.md
+++ b/workflow.md
@@ -49,7 +49,7 @@ Optional locally: `golangci-lint run --timeout=5m` if you have it installed (sam
 
 1. Push a branch and open a **Pull Request** against `main` so **Go CI** and **QA Pipeline** run on GitHub Actions.
 2. In the PR description, link work to GitHub issues using a **closing keyword** so the issue auto-closes when the PR merges: **`Closes #123`**, **`Fixes #123`**, or **`Resolves #123`** (one issue per line or comma-separated is fine). Plain **`Refs #123`** does **not** close the issue. See [Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-3. Treat **required** outcomes as: successful **unit tests** and **build** jobs (the QA summary job fails the workflow if those fail; lint and some security steps are configured as non-blocking—see `qa.yml`).
+3. Treat **required** outcomes as: successful **unit tests**, **build**, and **integration tests** (MySQL and MariaDB) jobs (the QA summary job fails the workflow if any of those fail; lint and some security steps are configured as non-blocking—see `qa.yml`).
 4. Read and act on **automated review** feedback (for example GitHub **Copilot** review, **Cursor Bugbot**, or similar): fix correctness, security, and clear regressions; use judgment on pure style suggestions.
 5. Re-push until checks you care about are green, then proceed with human review per team practice.
 

--- a/workflow.md
+++ b/workflow.md
@@ -48,9 +48,10 @@ Optional locally: `golangci-lint run --timeout=5m` if you have it installed (sam
 ## Pull requests, CI, and bot review
 
 1. Push a branch and open a **Pull Request** against `main` so **Go CI** and **QA Pipeline** run on GitHub Actions.
-2. Treat **required** outcomes as: successful **unit tests** and **build** jobs (the QA summary job fails the workflow if those fail; lint and some security steps are configured as non-blocking—see `qa.yml`).
-3. Read and act on **automated review** feedback (for example GitHub **Copilot** review, **Cursor Bugbot**, or similar): fix correctness, security, and clear regressions; use judgment on pure style suggestions.
-4. Re-push until checks you care about are green, then proceed with human review per team practice.
+2. In the PR description, link work to GitHub issues using a **closing keyword** so the issue auto-closes when the PR merges: **`Closes #123`**, **`Fixes #123`**, or **`Resolves #123`** (one issue per line or comma-separated is fine). Plain **`Refs #123`** does **not** close the issue. See [Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+3. Treat **required** outcomes as: successful **unit tests** and **build** jobs (the QA summary job fails the workflow if those fail; lint and some security steps are configured as non-blocking—see `qa.yml`).
+4. Read and act on **automated review** feedback (for example GitHub **Copilot** review, **Cursor Bugbot**, or similar): fix correctness, security, and clear regressions; use judgment on pure style suggestions.
+5. Re-push until checks you care about are green, then proceed with human review per team practice.
 
 ## Open backlog snapshot
 
@@ -58,14 +59,12 @@ Optional locally: `golangci-lint run --timeout=5m` if you have it installed (sam
 
 | # | Title |
 |---|--------|
-| 106 | Feature: add_connection — register a new named DSN at runtime (no restart) |
-| 104 | Enhancement: richer EXPLAIN as structured output (document existing explain_query) |
 | 103 | Feature: write_query tool with explicit confirmation for INSERT/UPDATE/DELETE |
 | 80 | [Feature]: Natural Language to SQL tool (ask_nl_sql) |
 | 64 | Add support for local LLMs (Ollama, LM Studio, llama.cpp) |
 | 24 | Add TiDB compatibility support |
 
-**Recently delivered (closed):** #102 (metrics HTTP sidecar), #117 (column masking), #119 (`schema_diff`), #120 (`search_schema`), #110 / #111 / #121 (retries, pagination, pool ping)—all on `main` as of PRs **#122**–**#124**.
+**Recently delivered (closed):** #106 (`add_connection`, merged PR **#127**); #104 (richer EXPLAIN, merged PR **#126**); earlier: #102 (metrics HTTP sidecar), #117 (column masking), #119 (`schema_diff`), #120 (`search_schema`), #110 / #111 / #121 (retries, pagination, pool ping)—on `main` via PRs **#122**–**#124** and subsequent merges.
 
 ## AI-specific notes
 


### PR DESCRIPTION
## Summary

- Add `pre-release-check` job to `release.yml`: runs unit + integration tests against MySQL 8.0 before GoReleaser fires; gates `goreleaser` on success (fixes the highest-severity gap — tagged commits were shipping without any QA)
- Fix no-op format check in `qa.yml`: replace `go fmt ./... || true` with `gofmt -l` enforcement that actually fails the job
- Expand `qa-summary` failure condition to include `integration-tests` and `integration-tests-mariadb` — previously only `unit-tests` and `build` blocked PRs
- Replace fragile `sleep 3` with a 20-iteration health-poll loop in `api-tests`
- Pin `golangci-lint` to `v1.64.8` (action `@v6`) to prevent surprise breakage from `latest`
- Align `docker/build-push-action` to `@v6` in `qa.yml` (was `@v5`; `release.yml` already used `@v6`)
- Remove stale issue #104 from `workflow.md` backlog (merged in PR #126)

Closes #128

## Test plan
- [x] `qa.yml` and `release.yml` parse as valid YAML (verified with ruby)
- [x] `gofmt -l .` returns empty — all source files are formatted
- [x] `go test ./...` passes locally
- [ ] GitHub Actions run green on this PR (Go CI + QA Pipeline)
- [ ] After merge: push a `v*` tag and confirm `goreleaser` job waits for `pre-release-check` in Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow changes now block PRs/releases on additional checks (gofmt + integration tests) and add readiness polling, which can cause new CI/release failures if assumptions about formatting, service startup, or MySQL readiness are wrong.
> 
> **Overview**
> **Hardens CI and release gating.** The QA workflow now *enforces formatting* via `gofmt -l`, pins `golangci-lint` (action `@v6`, `v1.64.8`), aligns `docker/build-push-action` to `@v6`, and replaces a fixed `sleep` with a `/health` poll before REST API smoke tests.
> 
> **Makes failures actionable and blocks releases earlier.** `qa-summary` now fails the workflow when MySQL/MariaDB integration tests fail (not just unit/build), and `release.yml` adds a `pre-release-check` job (build + unit + MySQL-backed integration tests) that `goreleaser` must pass before publishing.
> 
> Docs are updated to reflect the stricter required CI outcomes and to remove a stale backlog item; version docs are bumped to `1.7.0-rc.4` (README badge/example + changelog entry), and a workflow hardening implementation plan doc is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67a76dd85ea7d485a40ea69690dc2260b37d89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->