### PR TITLE
  feat: add MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS opt-in for diagnostic schema access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- **`MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS`** (opt-in, default off): lifts the default block on the read-only diagnostic schemas `information_schema`, `performance_schema`, and `sys`, so `run_query` / `explain_query` can reference them for index diagnostics (cardinality via `information_schema.STATISTICS`, index usage via `performance_schema.table_io_waits_summary_by_index_usage`, redundant/unused indexes via `sys.*`). The `mysql` schema remains blocked unconditionally, and access is still subject to the connection's MySQL grants. Orthogonal to `MYSQL_MCP_ALLOWED_DATABASES`: both are enforced, so when an allowlist is set the relevant system schemas must also be added to it. As part of this, `explain_query` now runs the same `ValidateSQLCombined` checks as `run_query` (it previously did not, so EXPLAIN could reach system schemas regardless of any guard). Configurable via env var or the `security.allow_system_schemas` config-file key.
+
 ## [1.7.0] - 2026-04-19
 
 General availability release. Promotes rc.4 to GA plus CI/release pipeline hardening.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Environment variables:
 | MYSQL_MCP_AUDIT_LOG | No | – | Path to audit log file |
 | MYSQL_MCP_ALLOWED_DATABASES | No | – | Comma-separated schema allowlist (empty = all allowed). With an allowlist, **`run_query`** rejects **`SHOW DATABASES`** / **`SHOW DATABASES LIKE`**—use **`list_databases`**. |
 | MYSQL_MCP_STRICT_READ_ONLY | No | 0 | Set `1` to enable `transaction_read_only=ON` on new connections |
+| MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS | No | 0 | Set `1` to allow **read-only** access to `information_schema`, `performance_schema`, and `sys` (for diagnostics: index cardinality, index usage, redundant/unused indexes). `mysql` stays blocked regardless. |
 | MYSQL_MCP_PROCESS_ADMIN | No | 0 | Set `1` to enable **`process_list`** / **`kill_query`** (extended); **`kill_query`** issues **`KILL QUERY`** (cancels the running statement only, not the connection) |
 | MYSQL_MCP_READ_AUDIT_TOOL | No | 0 | Set `1` to enable `read_audit_log` when audit path is set |
 | MYSQL_MCP_SLOW_QUERY_TOOL | No | 0 | Set `1` to enable `slow_query_log` tool (extended) |
@@ -985,13 +986,14 @@ export MYSQL_QUERY_TIMEOUT=30000    # Optional: timeout in ms (30 s) if you do n
 |----------|---------|
 | `MYSQL_MCP_ALLOWED_DATABASES` | Comma-separated schema allowlist. When set, tools that take a `database` argument must use an allowed name; `list_databases` / `database_size` only expose allowed schemas; `run_query` requires `database` and cannot be used to hop schemas via omission. **`run_query`** rejects **`SHOW DATABASES`** and **`SHOW DATABASES LIKE`** (use **`list_databases`**). Qualified names in SQL, **`EXPLAIN`** (including **`FORMAT=`** / **`EXTENDED`**), and inner DML in **`EXPLAIN`** are checked against the allowlist. **`slow_query_log`** (table mode) only returns `mysql.slow_log` rows whose **`db`** column matches an allowed schema (case-insensitive); rows with null/empty `db` are omitted. |
 | `MYSQL_MCP_STRICT_READ_ONLY` | When `1`, new driver connections run with `transaction_read_only=ON` (harder to accidentally issue writes if grants allow them). |
+| `MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS` | When `1`, lifts the default block on the read-only diagnostic schemas `information_schema`, `performance_schema`, and `sys` so `run_query` / `explain_query` may reference them (e.g. `information_schema.STATISTICS` for index cardinality, `sys.schema_redundant_indexes` / `sys.schema_unused_indexes`, `performance_schema.table_io_waits_summary_by_index_usage`). The `mysql` schema remains blocked unconditionally. Off by default; reads still require the connection's MySQL grants. This flag and `MYSQL_MCP_ALLOWED_DATABASES` are **orthogonal and both enforced**: the flag lifts the hardcoded system-schema guard, while the allowlist (when set) independently rejects any schema not on it. So if you run with an allowlist, you must **also add `information_schema` / `performance_schema` / `sys` to `MYSQL_MCP_ALLOWED_DATABASES`** for these queries to pass; with no allowlist (the default), the flag alone is sufficient. The flag never unlocks `mysql`. |
 | `MYSQL_MCP_PROCESS_ADMIN` | Enables **`process_list`** and **`kill_query`** (issues **`KILL QUERY`**, not connection kill; plus HTTP `/api/processlist`, `/api/kill`). Requires appropriate MySQL privileges (`CONNECTION_ADMIN` / `PROCESS`, etc.). |
 | `MYSQL_MCP_READ_AUDIT_TOOL` | Enables **`read_audit_log`** when **`MYSQL_MCP_AUDIT_LOG`** is set (tail of the audit JSON file). |
 | `MYSQL_MCP_SLOW_QUERY_TOOL` | Enables **`slow_query_log`** (reads `mysql.slow_log` when `log_output` includes `TABLE`, otherwise returns file settings). |
 
 **`server_info`:** Pass **`detailed: true`** (MCP) or **`?detailed=1`** (HTTP) for ping latency, **`Threads_running`**, **`Slow_queries`**, **`Questions`**, and InnoDB buffer pool hit rate when stats are available. If **`MYSQL_MCP_TOKEN_TRACKING=1`**, **`token_metrics`** is always included (cumulative since process start).
 
-YAML file equivalents live under **`security:`** in the config file (`allowed_databases`, `strict_read_only`, `process_admin`, `read_audit_tool`, `slow_query_tool`).
+YAML file equivalents live under **`security:`** in the config file (`allowed_databases`, `strict_read_only`, `allow_system_schemas`, `process_admin`, `read_audit_tool`, `slow_query_tool`).
 
 ## Testing
 

--- a/cmd/mysql-mcp-server/main.go
+++ b/cmd/mysql-mcp-server/main.go
@@ -158,6 +158,7 @@ func main() {
 		log.Fatalf("config error: %v", err)
 	}
 	initAccessControl(cfg.AllowedDatabases)
+	util.SetAllowSystemSchemas(cfg.AllowSystemSchemas)
 
 	// Daemon mode requires HTTP mode; defer until after config load so we can check.
 	if parsed.daemon {

--- a/cmd/mysql-mcp-server/tools_extended.go
+++ b/cmd/mysql-mcp-server/tools_extended.go
@@ -158,6 +158,19 @@ func toolExplainQuery(
 			return nil, ExplainQueryOutput{}, err
 		}
 	}
+	// Enhanced SQL validation using parser + regex defense-in-depth, matching
+	// run_query. Without this, EXPLAIN bypasses the system-schema guard (and the
+	// MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS opt-in): the allowlist check below is a no-op
+	// when no allowlist is configured, so EXPLAIN could otherwise reach mysql.* /
+	// information_schema.* etc. regardless of the flag.
+	if err := util.ValidateSQLCombined(sqlText); err != nil {
+		logWarn("query rejected by validator", map[string]interface{}{
+			"tool":  "explain_query",
+			"error": err.Error(),
+			"query": util.TruncateQuery(sqlText, 200),
+		})
+		return nil, ExplainQueryOutput{}, fmt.Errorf("query validation failed: %w", err)
+	}
 	if err := requireReferencedSchemasInQuery(sqlText); err != nil {
 		return nil, ExplainQueryOutput{}, err
 	}

--- a/cmd/mysql-mcp-server/tools_extended_test.go
+++ b/cmd/mysql-mcp-server/tools_extended_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/askdba/mysql-mcp-server/internal/config"
+	"github.com/askdba/mysql-mcp-server/internal/util"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -375,6 +376,97 @@ func TestToolExplainQueryNonSelect(t *testing.T) {
 	}
 	if err.Error() != "only SELECT statements can be explained" {
 		t.Errorf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestToolExplainQuerySystemSchemaDefaultDeny verifies EXPLAIN blocks system
+// schemas by default (no allowlist, flag off) and never reaches the DB.
+func TestToolExplainQuerySystemSchemaDefaultDeny(t *testing.T) {
+	mock, cleanup := setupExtendedMockDB(t)
+	defer cleanup()
+
+	for _, q := range []string{
+		"SELECT * FROM information_schema.tables",
+		"SELECT * FROM performance_schema.events_statements_summary_by_digest",
+		"SELECT * FROM sys.session",
+		"SELECT * FROM mysql.user",
+	} {
+		_, _, err := toolExplainQuery(context.Background(), &mcp.CallToolRequest{}, ExplainQueryInput{SQL: q})
+		// Assert the rejection comes from the validator (before any DB access),
+		// not from an incidental "unexpected DB call" sqlmock error — otherwise
+		// the test would pass even if EXPLAIN reached the DB.
+		if err == nil {
+			t.Errorf("expected EXPLAIN of %q to be blocked by default", q)
+		} else if !strings.Contains(err.Error(), "query validation failed") {
+			t.Errorf("expected validation rejection for %q (proving no DB call), got: %v", q, err)
+		}
+	}
+	// Belt-and-suspenders: no mock.ExpectQuery was registered, so any DB call
+	// would also surface here.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestToolExplainQuerySystemSchemaOptInUnlocks verifies that with
+// MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS on, EXPLAIN of a read-only system schema passes
+// validation and reaches the DB, while mysql stays blocked.
+func TestToolExplainQuerySystemSchemaOptInUnlocks(t *testing.T) {
+	mock, cleanup := setupExtendedMockDB(t)
+	defer cleanup()
+
+	util.SetAllowSystemSchemas(true)
+	defer util.SetAllowSystemSchemas(false)
+
+	// information_schema now reaches the DB (validation passes).
+	mock.ExpectQuery(`EXPLAIN FORMAT=JSON SELECT \* FROM information_schema.STATISTICS`).
+		WillReturnRows(sqlmock.NewRows([]string{"EXPLAIN"}).AddRow(
+			`{"query_block":{"cost_info":{"query_cost":"1.0"},"table":{"table_name":"STATISTICS","access_type":"ALL","rows":1,"filtered":100}}}`,
+		))
+	if _, _, err := toolExplainQuery(context.Background(), &mcp.CallToolRequest{},
+		ExplainQueryInput{SQL: "SELECT * FROM information_schema.STATISTICS"}); err != nil {
+		t.Fatalf("expected EXPLAIN of information_schema to pass with flag on, got: %v", err)
+	}
+
+	// mysql must remain blocked even with the flag on — and the rejection must
+	// come from the validator (no DB call), not an unexpected-query sqlmock error.
+	if _, _, err := toolExplainQuery(context.Background(), &mcp.CallToolRequest{},
+		ExplainQueryInput{SQL: "SELECT * FROM mysql.user"}); err == nil {
+		t.Error("expected EXPLAIN of mysql.user to remain blocked even with flag on")
+	} else if !strings.Contains(err.Error(), "query validation failed") {
+		t.Errorf("expected validation rejection for mysql.user (proving no DB call), got: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestToolExplainQuerySystemSchemaAllowlistStillApplies codifies the documented
+// policy: MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS and MYSQL_MCP_ALLOWED_DATABASES are
+// orthogonal and both enforced. With an allowlist set that does NOT include
+// information_schema, the flag does not exempt it — the allowlist independently
+// rejects the reference.
+func TestToolExplainQuerySystemSchemaAllowlistStillApplies(t *testing.T) {
+	mock, cleanup := setupExtendedMockDB(t)
+	defer cleanup()
+
+	initAccessControl([]string{"appdb"}) // allowlist excludes information_schema
+	defer initAccessControl(nil)
+	util.SetAllowSystemSchemas(true)
+	defer util.SetAllowSystemSchemas(false)
+
+	_, _, err := toolExplainQuery(context.Background(), &mcp.CallToolRequest{},
+		ExplainQueryInput{SQL: "SELECT * FROM information_schema.STATISTICS", Database: "appdb"})
+	if err == nil {
+		t.Fatal("expected information_schema to be rejected by the allowlist even with the flag on")
+	}
+	if !strings.Contains(err.Error(), "MYSQL_MCP_ALLOWED_DATABASES") {
+		t.Errorf("expected an allowlist rejection (not a validator/DB error), got: %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,11 +98,12 @@ type Config struct {
 	MaskColumns []string
 
 	// Security / access (optional)
-	AllowedDatabases []string // Empty = all databases allowed (subject to MySQL grants)
-	StrictReadOnly   bool     // SET transaction_read_only=ON on each driver connection (DSN param)
-	ProcessAdmin     bool     // Enable process_list and kill_query (extended tools)
-	ReadAuditTool    bool     // Enable read_audit_log when AuditLogPath is set (extended)
-	SlowQueryTool    bool     // Enable slow_query_log tool (extended)
+	AllowedDatabases   []string // Empty = all databases allowed (subject to MySQL grants)
+	StrictReadOnly     bool     // SET transaction_read_only=ON on each driver connection (DSN param)
+	AllowSystemSchemas bool     // Permit read-only access to information_schema/performance_schema/sys (mysql stays blocked)
+	ProcessAdmin       bool     // Enable process_list and kill_query (extended tools)
+	ReadAuditTool      bool     // Enable read_audit_log when AuditLogPath is set (extended)
+	SlowQueryTool      bool     // Enable slow_query_log tool (extended)
 }
 
 // Load reads configuration from config file (if present) and environment variables.
@@ -262,6 +263,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("MYSQL_MCP_STRICT_READ_ONLY"); v != "" {
 		cfg.StrictReadOnly = getEnvBool("MYSQL_MCP_STRICT_READ_ONLY")
+	}
+	if v := os.Getenv("MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS"); v != "" {
+		cfg.AllowSystemSchemas = getEnvBool("MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS")
 	}
 	if v := os.Getenv("MYSQL_MCP_PROCESS_ADMIN"); v != "" {
 		cfg.ProcessAdmin = getEnvBool("MYSQL_MCP_PROCESS_ADMIN")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -529,6 +529,7 @@ func TestSecurityEnvOverrides(t *testing.T) {
 	_ = os.Setenv("MYSQL_DSN", "user:pass@tcp(localhost:3306)/db")
 	_ = os.Setenv("MYSQL_MCP_ALLOWED_DATABASES", " a , b, c ")
 	_ = os.Setenv("MYSQL_MCP_STRICT_READ_ONLY", "1")
+	_ = os.Setenv("MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS", "1")
 	_ = os.Setenv("MYSQL_MCP_PROCESS_ADMIN", "1")
 	_ = os.Setenv("MYSQL_MCP_READ_AUDIT_TOOL", "true")
 	_ = os.Setenv("MYSQL_MCP_SLOW_QUERY_TOOL", "y")
@@ -541,6 +542,9 @@ func TestSecurityEnvOverrides(t *testing.T) {
 	}
 	if !cfg.StrictReadOnly || !cfg.ProcessAdmin || !cfg.ReadAuditTool || !cfg.SlowQueryTool {
 		t.Fatalf("flags: strict=%v admin=%v audit=%v slow=%v", cfg.StrictReadOnly, cfg.ProcessAdmin, cfg.ReadAuditTool, cfg.SlowQueryTool)
+	}
+	if !cfg.AllowSystemSchemas {
+		t.Fatalf("expected AllowSystemSchemas=true from MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS=1")
 	}
 	set := AllowedDatabaseSet(cfg.AllowedDatabases)
 	if len(set) != 3 {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -83,11 +83,12 @@ type FileFeatureConfig struct {
 
 // FileSecurityConfig represents access-control and privileged tool flags.
 type FileSecurityConfig struct {
-	AllowedDatabases []string `yaml:"allowed_databases" json:"allowed_databases"`
-	StrictReadOnly   bool     `yaml:"strict_read_only" json:"strict_read_only"`
-	ProcessAdmin     bool     `yaml:"process_admin" json:"process_admin"`
-	ReadAuditTool    bool     `yaml:"read_audit_tool" json:"read_audit_tool"`
-	SlowQueryTool    bool     `yaml:"slow_query_tool" json:"slow_query_tool"`
+	AllowedDatabases   []string `yaml:"allowed_databases" json:"allowed_databases"`
+	StrictReadOnly     bool     `yaml:"strict_read_only" json:"strict_read_only"`
+	AllowSystemSchemas bool     `yaml:"allow_system_schemas" json:"allow_system_schemas"`
+	ProcessAdmin       bool     `yaml:"process_admin" json:"process_admin"`
+	ReadAuditTool      bool     `yaml:"read_audit_tool" json:"read_audit_tool"`
+	SlowQueryTool      bool     `yaml:"slow_query_tool" json:"slow_query_tool"`
 }
 
 // FileLoggingConfig represents logging settings in the config file.
@@ -296,6 +297,9 @@ func (fc *FileConfig) ToConfig() *Config {
 	if fc.Security.StrictReadOnly {
 		cfg.StrictReadOnly = true
 	}
+	if fc.Security.AllowSystemSchemas {
+		cfg.AllowSystemSchemas = true
+	}
 	if fc.Security.ProcessAdmin {
 		cfg.ProcessAdmin = true
 	}
@@ -398,11 +402,12 @@ func PrintConfig(cfg *Config) string {
 			TokenCard:     cfg.TokenCard,
 		},
 		Security: FileSecurityConfig{
-			AllowedDatabases: cfg.AllowedDatabases,
-			StrictReadOnly:   cfg.StrictReadOnly,
-			ProcessAdmin:     cfg.ProcessAdmin,
-			ReadAuditTool:    cfg.ReadAuditTool,
-			SlowQueryTool:    cfg.SlowQueryTool,
+			AllowedDatabases:   cfg.AllowedDatabases,
+			StrictReadOnly:     cfg.StrictReadOnly,
+			AllowSystemSchemas: cfg.AllowSystemSchemas,
+			ProcessAdmin:       cfg.ProcessAdmin,
+			ReadAuditTool:      cfg.ReadAuditTool,
+			SlowQueryTool:      cfg.SlowQueryTool,
 		},
 		Logging: FileLoggingConfig{
 			JSONFormat:    cfg.JSONLogging,

--- a/internal/util/sql_parser.go
+++ b/internal/util/sql_parser.go
@@ -67,6 +67,27 @@ var DangerousSchemas = map[string]bool{
 	"sys":                true,
 }
 
+// systemReadSchemas are the read-only diagnostic schemas that may be unlocked
+// via MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS (e.g. index cardinality, index usage,
+// redundant-index detection). `mysql` is deliberately excluded — it holds
+// credentials and grants and stays blocked regardless of the flag.
+var systemReadSchemas = map[string]bool{
+	"information_schema": true,
+	"performance_schema": true,
+	"sys":                true,
+}
+
+// allowSystemSchemas, when true, permits read access to systemReadSchemas.
+// Off by default; set once at startup via SetAllowSystemSchemas.
+var allowSystemSchemas bool
+
+// SetAllowSystemSchemas toggles read access to the read-only system schemas
+// (information_schema, performance_schema, sys). The `mysql` schema remains
+// blocked regardless. Intended to be called once during startup from config.
+func SetAllowSystemSchemas(v bool) {
+	allowSystemSchemas = v
+}
+
 // ValidateSQLWithParser performs SQL validation using a proper SQL parser.
 // This is more robust than regex-based validation as it understands SQL syntax.
 func ValidateSQLWithParser(sqlText string) error {
@@ -285,7 +306,8 @@ func checkTableExpr(tableExpr sqlparser.TableExpr) error {
 		if tableName, ok := t.Expr.(sqlparser.TableName); ok {
 			// Check if accessing a dangerous schema
 			qualifier := strings.ToLower(tableName.Qualifier.String())
-			if qualifier != "" && DangerousSchemas[qualifier] {
+			if qualifier != "" && DangerousSchemas[qualifier] &&
+				!(allowSystemSchemas && systemReadSchemas[qualifier]) {
 				return &ParserValidationError{
 					Reason:    "access to system schema is not allowed",
 					Statement: qualifier,

--- a/internal/util/sql_parser_test.go
+++ b/internal/util/sql_parser_test.go
@@ -200,6 +200,39 @@ func TestValidateSQLWithParser_SystemSchemas(t *testing.T) {
 	}
 }
 
+func TestValidateSQLWithParser_AllowSystemSchemas(t *testing.T) {
+	// Opt-in (MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS) unlocks the read-only diagnostic
+	// schemas but must NOT unlock `mysql`.
+	defer SetAllowSystemSchemas(false) // restore default for other tests
+	SetAllowSystemSchemas(true)
+
+	allowed := []struct {
+		query  string
+		schema string
+	}{
+		{"SELECT TABLE_NAME, CARDINALITY FROM information_schema.STATISTICS", "information_schema"},
+		{"SELECT * FROM performance_schema.table_io_waits_summary_by_index_usage", "performance_schema"},
+		{"SELECT * FROM sys.schema_redundant_indexes", "sys"},
+		{"SELECT * FROM Information_Schema.STATISTICS", "information_schema (case)"},
+	}
+	for _, tc := range allowed {
+		t.Run("allowed/"+tc.schema, func(t *testing.T) {
+			if err := ValidateSQLCombined(tc.query); err != nil {
+				t.Errorf("expected %s to be allowed when flag is on, got: %v\nQuery: %s", tc.schema, err, tc.query)
+			}
+		})
+	}
+
+	// `mysql` stays blocked even with the flag on.
+	for _, q := range []string{"SELECT * FROM mysql.user", "SELECT * FROM MYSQL.user"} {
+		t.Run("still-blocked/mysql", func(t *testing.T) {
+			if err := ValidateSQLCombined(q); err == nil {
+				t.Errorf("expected mysql schema to remain blocked even with flag on\nQuery: %s", q)
+			}
+		})
+	}
+}
+
 func TestValidateSQLWithParser_SQLInjectionAttempts(t *testing.T) {
 	// Test injection attempts that should be caught by the parser
 	parserCaught := []struct {

--- a/internal/util/sql_validator.go
+++ b/internal/util/sql_validator.go
@@ -171,8 +171,17 @@ var blockedPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`--`),
 	regexp.MustCompile(`/\*`),
 
-	// System schema access (information disclosure)
+	// System schema access (information disclosure). `mysql` is always blocked;
+	// the read-only diagnostic schemas are gated separately via
+	// systemReadSchemaPatterns so they can be unlocked with MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS.
 	regexp.MustCompile(`(?i)\bMYSQL\s*\.\b`),
+}
+
+// systemReadSchemaPatterns match the read-only diagnostic schemas that are
+// blocked by default but may be unlocked via MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS
+// (SetAllowSystemSchemas). `mysql` is intentionally NOT here — it stays in
+// blockedPatterns and is always rejected.
+var systemReadSchemaPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\bINFORMATION_SCHEMA\s*\.\b`),
 	regexp.MustCompile(`(?i)\bPERFORMANCE_SCHEMA\s*\.\b`),
 	regexp.MustCompile(`(?i)\bSYS\s*\.\b`),
@@ -218,6 +227,20 @@ func ValidateSQL(sqlText string) error {
 			return &SQLValidationError{
 				Reason:  "query contains blocked pattern",
 				Pattern: pattern.String(),
+			}
+		}
+	}
+
+	// Read-only diagnostic system schemas are blocked unless explicitly unlocked
+	// via MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS (SetAllowSystemSchemas). `mysql` is never
+	// unlocked here — it remains in blockedPatterns above.
+	if !allowSystemSchemas {
+		for _, pattern := range systemReadSchemaPatterns {
+			if pattern.MatchString(scan) {
+				return &SQLValidationError{
+					Reason:  "query contains blocked pattern",
+					Pattern: pattern.String(),
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Add opt-in `MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS` environment variable and `security.allow_system_schemas` config key to lift the block on read-only diagnostic system schemas (`information_schema`, `performance_schema`, `sys`) for `run_query` / `explain_query`. The `mysql` schema remains unconditionally blocked. Access is still subject to the connection's MySQL grants.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration/build changes
- [ ] 🧪 Test improvements
- [ ] ♻️ Refactoring (no functional changes)

## Changes Made

- Add `MYSQL_MCP_ALLOW_SYSTEM_SCHEMAS` env var (default off) to lift block on `information_schema`, `performance_schema`, and `sys` in both DangerousSchemas (parser) and blockedPatterns (regex) validators
- Add `security.allow_system_schemas` config-file key (overrides via env var)
- `mysql` schema remains blocked unconditionally regardless of the flag
- `explain_query` now runs `ValidateSQLCombined` checks consistent with `run_query` (previously it did not, so EXPLAIN could reach system schemas regardless of guards)
- Orthogonal to `MYSQL_MCP_ALLOWED_DATABASES`: both are enforced, so when an allowlist is set the relevant system schemas must also be added to it
- `ValidateWhereClause` (structured WHERE-builder path, not used by `run_query`) intentionally untouched

## Testing

- [x] All existing tests pass (`go test ./...`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Added parser + regex unlock tests:
- Default-deny behavior unchanged when flag is off
- `mysql` schema stays blocked even when flag is on
- `information_schema`, `performance_schema`, `sys` accessible when flag is on
- Config env-override test

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Screenshots (if applicable)

N/A

## Additional Notes

All four system schemas were previously hard-blocked by `DangerousSchemas` (parser) and `blockedPatterns` (regex), preventing legitimate read-only diagnostics such as index cardinality (`information_schema.STATISTICS`), index usage (`performance_schema.table_io_waits_summary_by_index_usage`), and redundant/unused index detection (`sys.*`). `MYSQL_MCP_ALLOWED_DATABASES` could not help because the system schema guard runs before/independently of the allowlist. This PR makes access to the diagnostic schemas opt-in while keeping `mysql` unconditionally blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in setting to enable read-only access to diagnostic schemas (information_schema, performance_schema, sys); mysql remains blocked. When an allowlist is used, system schemas must be included there.

* **Bug Fixes**
  * explain_query now enforces the same SQL validation as run_query.

* **Documentation**
  * Config docs and changelog updated to document the new setting and YAML equivalent.

* **Tests**
  * Added tests covering system-schema opt-in and interplay with allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->